### PR TITLE
Adding a simple legged odometry to wholeBodyDynamicsTree

### DIFF
--- a/src/modules/graspAndStepDemo/README.md
+++ b/src/modules/graspAndStepDemo/README.md
@@ -32,6 +32,8 @@ Events
 |:-----------:|:-------------:|:-----------:|
 | `e_grasping_enabled`  | The `**GraspDemo` module is running and the grasping behaviour is **active** | Sent by the `**GraspDemo` module on `events:i` port |
 | `e_grasping_disabled` | The `**GraspDemo` module is running and the grasping behaviour is **not active** | Sent by the `**GraspDemo` module on `events:i` port |
+| `e_grasping_disabling_requested` | |
+| `e_grasping_enabling_requested` | |
 | `e_weight_on_left_foot` | The overall external force acting on the `l_foot` link is greater than or equal to the `force_threshold` `steppingDemo` parameter | Raised internally by the `steppingMonitor` class |
 | `e_no_weight_on_left_foot` | The overall external force acting on the `l_foot` link is lower than the `force_threshold` `steppingDemo` parameter | Raised internally by the `steppingMonitor` class |
 | `e_weight_on_right_foot` | The overall external force acting on the `r_foot` link is greater than or equal to the `force_threshold` `steppingDemo`  parameter | Raised internally by the `steppingMonitor` class |

--- a/src/modules/graspAndStepDemo/lua/fsm_graspAndStep.lua
+++ b/src/modules/graspAndStepDemo/lua/fsm_graspAndStep.lua
@@ -26,6 +26,4 @@ return rfsm.state {
 
     rfsm.transition { src='ST_GRASPING', tgt='ST_LEFT_STEPPING',  events={ 'e_left_step_requested',  'e_grasping_disabled' } },
     rfsm.transition { src='ST_LEFT_STEPPING', tgt='ST_GRASPING',  events={ 'e_left_step_completed' } },
-
-
 }

--- a/src/modules/graspAndStepDemo/lua/fsm_grasping.lua
+++ b/src/modules/graspAndStepDemo/lua/fsm_grasping.lua
@@ -1,14 +1,45 @@
 
-TorqueBalancingSetPoints = {}
-TorqueBalancingSetPoints.__index = TorqueBalancingSetPoints
+return rfsm.state {
+    ---------------------------------------------------------------------------------------
+    -- state GRASPING_ACTIVE                                                       --
+    -- In this state the robot is standing on double support, and is grasping             --
+    ---------------------------------------------------------------------------------------
+    ST_GRASPING_ACTIVATION_REQUESTED =  rfsm.state{
+        entry=function()
+            gas_sendStringToRPC(graspingModule_rpc,"start")
+        end,
+    },
 
-function TorqueBalancingSetPoints.create(balance)
-   local acnt = {}             -- our new object
-   setmetatable(acnt,Account)  -- make Account handle lookup
-   acnt.balance = balance      -- initialize our object
-   return acnt
-end
 
-function Account:withdraw(amount)
-   self.balance = self.balance - amount
-end
+    ST_GRASPING_ACTIVE =  rfsm.state{
+    },
+
+    ------------------------------------------------------------------------------------------
+    -- state GRASPING_DISABLING_REQUESTED                                                   --
+    -- In this state the robot is standing on double support, and a stop has been requested --
+    ------------------------------------------------------------------------------------------
+    ST_GRASPING_DISABLING_REQUESTED =  rfsm.state{
+        entry=function()
+            gas_sendStringToRPC(graspingModule_rpc,"stop")
+        end,
+    },
+
+    ST_GRASPING_DISABLED =  rfsm.state{
+    },
+
+
+    rfsm.transition { src='initial', tgt='ST_GRASPING_ACTIVATION_REQUESTED' },
+
+    -- Enabling grasping flow
+    rfsm.transition { src='ST_GRASPING_DISABLED', tgt='ST_GRASPING_ACTIVATION_REQUESTED',  events={ 'e_grasping_enabling_requested' } },
+    rfsm.transition { src='ST_GRASPING_ACTIVATION_REQUESTED', tgt='ST_GRASPING_ACTIVE',  events={ 'e_grasping_enabled' } },
+
+    -- Disabling grasping flow
+    rfsm.transition { src='ST_GRASPING_ACTIVE', tgt='ST_GRASPING_DISABLING_REQUESTED',  events={ 'e_grasping_disabling_requested' } },
+    rfsm.transition { src='ST_GRASPING_DISABLING_REQUESTED', tgt='ST_GRASPING_DISABLED',  events={ 'e_grasping_disabled' } },
+
+    -- Timeout transitions
+    rfsm.transition { src='ST_GRASPING_ACTIVATION_REQUESTED', tgt='ST_GRASPING_DISABLED',  events={ 'e_after(5.0)','e_grasping_disabled' } },
+    rfsm.transition { src='ST_GRASPING_DISABLING_REQUESTED', tgt='ST_GRASPING_ACTIVE',  events={ 'e_after(5.0)','e_grasping_enabled' } },
+
+}

--- a/src/modules/graspAndStepDemo/lua/fsm_left_step.lua
+++ b/src/modules/graspAndStepDemo/lua/fsm_left_step.lua
@@ -6,6 +6,7 @@ return rfsm.state {
     -- but is shifting its weight to the support foot                                    --
     ---------------------------------------------------------------------------------------
     ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_RIGHT_FOOT = rfsm.state{
+        -- set new com setpoint (for single support)
     },
 
     ---------------------------------------------------------------------------------------
@@ -15,6 +16,7 @@ return rfsm.state {
     ---------------------------------------------------------------------------------------
      -- Not using nesting for now because there is a bug in rfsm tools rfsm.load("fsm_swing.lua"),
     ST_SINGLESUPPORT_LEFT_SWING = rfsm.state{
+        -- set com setpoint
     };
 
 
@@ -24,6 +26,7 @@ return rfsm.state {
     -- but is shifting its weight to the support foot                                    --
     ---------------------------------------------------------------------------------------
     ST_DOUBLESUPPORT_TRANSFER_WEIGHT_FROM_RIGHT_FOOT = rfsm.state{
+        --
     },
 
     ----------------------------------
@@ -34,7 +37,7 @@ return rfsm.state {
     rfsm.transition { src='initial', tgt='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_RIGHT_FOOT' },
 
     -- Sensor transitions
-    rfsm.transition { src='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_RIGHT_FOOT', tgt='ST_SINGLESUPPORT_SWING', events={ 'e_no_weight_on_left_foot' } },
+    rfsm.transition { src='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_RIGHT_FOOT', tgt='ST_SINGLESUPPORT_SWING', events={ 'e_com_motion_done' } },
     rfsm.transition { src='ST_SINGLESUPPORT_SWING', tgt='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_FROM_RIGHT_FOOT', events={ 'e_left_leg_swing_motiondone' } },
 
 

--- a/src/modules/graspAndStepDemo/lua/fsm_right_step.lua
+++ b/src/modules/graspAndStepDemo/lua/fsm_right_step.lua
@@ -34,7 +34,7 @@ return rfsm.state {
     rfsm.transition { src='initial', tgt='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_LEFT_FOOT' },
 
     -- Sensor transitions
-    rfsm.transition { src='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_LEFT_FOOT', tgt='ST_SINGLESUPPORT_SWING', events={ 'e_no_weight_on_right_foot' } },
+    rfsm.transition { src='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_LEFT_FOOT', tgt='ST_SINGLESUPPORT_SWING', events={ 'e_com_motion_done' } },
     rfsm.transition { src='ST_SINGLESUPPORT_SWING', tgt='ST_DOUBLESUPPORT_TRANSFER_WEIGHT_TO_CENTER', events={ 'e_right_leg_swing_motiondone' } },
 
 

--- a/src/modules/wholeBodyDynamicsTree/CMakeLists.txt
+++ b/src/modules/wholeBodyDynamicsTree/CMakeLists.txt
@@ -8,7 +8,7 @@ PROJECT(${PROJECTNAME})
 
 find_package(YARP REQUIRED)
 find_package(ICUB REQUIRED)
-find_package(iDynTree REQUIRED)
+find_package(iDynTree 0.3.2 REQUIRED)
 
 #Thrift configuration
 include(YarpIDL)

--- a/src/modules/wholeBodyDynamicsTree/CMakeLists.txt
+++ b/src/modules/wholeBodyDynamicsTree/CMakeLists.txt
@@ -8,7 +8,7 @@ PROJECT(${PROJECTNAME})
 
 find_package(YARP REQUIRED)
 find_package(ICUB REQUIRED)
-find_package(iDynTree 0.3.2 REQUIRED)
+find_package(iDynTree REQUIRED)
 
 #Thrift configuration
 include(YarpIDL)

--- a/src/modules/wholeBodyDynamicsTree/app/conf/wholeBodyDynamicsTree.ini
+++ b/src/modules/wholeBodyDynamicsTree/app/conf/wholeBodyDynamicsTree.ini
@@ -78,3 +78,8 @@ left_foot_subtree   = ((l_foot),l_foot)
 right_foot_subtree  = ((r_foot),r_foot)
 left_arm_subtree   = ((l_upper_arm,l_elbow_1,l_forearm,l_wrist_1,l_hand),l_hand)
 right_arm_subtree   = ((r_upper_arm,r_elbow_1,r_forearm,r_wrist_1,r_hand),r_hand)
+
+# Options for simple legged odometry
+[SIMPLE_LEGGED_ODOMETRY]
+initial_world_frame codyco_balancing_world
+initial_fixed_link  l_foot 

--- a/src/modules/wholeBodyDynamicsTree/app/conf/wholeBodyDynamicsTree.ini
+++ b/src/modules/wholeBodyDynamicsTree/app/conf/wholeBodyDynamicsTree.ini
@@ -82,4 +82,5 @@ right_arm_subtree   = ((r_upper_arm,r_elbow_1,r_forearm,r_wrist_1,r_hand),r_hand
 # Options for simple legged odometry
 [SIMPLE_LEGGED_ODOMETRY]
 initial_world_frame codyco_balancing_world
-initial_fixed_link  l_foot 
+initial_fixed_link  l_foot
+floating_base_frame root_link

--- a/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamicsTree/simpleLeggedOdometry.h
+++ b/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamicsTree/simpleLeggedOdometry.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Robotics, Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
+ * Author: Silvio Traversaro
+ * email: silvio.traversaro@iit.it
+ *
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+ */
+
+#ifndef _SIMPLE_LEGGED_ODOMETRY_
+#define _SIMPLE_LEGGED_ODOMETRY_
+
+#include <iCub/iDynTree/DynTree.h>
+
+/**
+ * This class implements a simple legged odometry scheme for a generic robot.
+ *
+ * Under the assumption that at least a link of the robot at the time is
+ * not moving (no slippage), it computes the estimate of the transform
+ * between a inertial/world frame and the robot floating base.
+ *
+ * The algorithm implemented is the following :
+ *
+ * 1a) At start (or at reset) the user of the class specifies:
+ *       * a frame (world) that should be assumed as the inertial/world frame
+ *       * a frame (fixed) that is rigidly attached to a link that is not moving
+ *         with respect to the specified inertial frame.
+ *     At the start, the world_H_fixed (${}^{world} H_{fixed}$) transfomr between this two specified
+ *     frames will be saved.
+ * 1b) At this point, the getWorldToFrameTransform(int frame_id) will return the world_H_frame
+ *      ( ${}^{world} H_{frame}$ ) transform simply by computing the forward kinematics from the fixed frame
+ *     to the frame specified by frame_id : world_H_frame = world_H_fixed * fixed_H_frame(qj)
+ *                                          ${}^{world} H_{frame} = {}^{world} H_{fixed} {}^{fixed} H_{frame}(qj)$
+ * 2) If the fixed frame changes, we can simply change the frame used as "fixed", and consistently update the
+ *      world_H_fixed transform to be equal to world_H_new_fixed =  world_H_old_fixed * old_fixed_H_new_fixed(qj) :
+ *      ${}^{world} H_{fixed} = {}^{world} H_{old_fixed} {}^{old_fixed} H_{new_fixed}(qj)$
+ * 2b) After the update, the getWorldToFrameTransform(int frame_id) can be obtained as at the point 1b .
+ *
+ * \note we should update the state used by the odometry by calling the appropritate getDynTree().setAng() method.
+ */
+class simpleLeggedOdometry
+{
+    private:
+        iCub::iDynTree::DynTree * odometry_model;
+        int current_fixed_link_id;
+        KDL::Frame world_H_fixed;
+
+    public:
+        simpleLeggedOdometry();
+
+        ~simpleLeggedOdometry();
+
+        bool init(KDL::CoDyCo::UndirectedTree & undirected_tree,
+                  const std::string & initial_world_frame_position,
+                  const std::string & initial_fixed_link);
+
+        bool init(KDL::CoDyCo::UndirectedTree & undirected_tree,
+                  const int initial_world_frame_position_index,
+                  const int initial_fixed_link_index);
+
+        bool reset(const std::string & initial_world_frame_position,
+                   const std::string & initial_fixed_link);
+
+        bool reset(const int initial_world_frame_position_index,
+                   const int initial_fixed_link_index);
+
+        /**
+         * Change the link that the odometry assumes to be fixed with the
+         * inertial/world frame
+         */
+        bool changeFixedLink(const std::string & new_fixed_link_name);
+
+        /**
+         * Change the link that the odometry assumes to be fixed with the
+         * inertial/world frame
+         */
+        bool changeFixedLink(const int & new_fixed_link_id);
+
+        /**
+         * Get the link currently considered fixed with rispect to the inertial frame.
+         * @return the name of the link currently considered fixed.
+         */
+        std::string getCurrentFixedLink();
+
+        /**
+         * Get the world_H_frame transform.
+         *
+         */
+        KDL::Frame getWorldFrameTransform(const int frame_index);
+
+        // Access underling models
+        /**
+         * Get the used DynTree object .
+         */
+        iCub::iDynTree::DynTree & getDynTree();
+
+};
+
+#endif

--- a/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamicsTree/wholeBodyDynamicsModule.h
+++ b/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamicsTree/wholeBodyDynamicsModule.h
@@ -75,6 +75,23 @@ public:
      */
     virtual bool resetOffset(const std::string& calib_code);
 
+  /**
+   * Reset the odometry world to be (initially) a frame specified in the robot model,
+   * and specify a link that is assumed to be fixed in the odometry.
+   * @param initial_world_frame the frame of the robot model that is assume to be initially
+   *        coincident with the world/inertial frame.
+   * @param new_fixed_link the name of the link that should be initially fixed
+   * @return true/false on success/failure (typically if the frame/link names are wrong)
+   */
+    virtual bool resetSimpleLeggedOdometry(const std::string& initial_world_frame, const std::string& initial_fixed_link);
+
+  /**
+   * Change the link that is considered fixed by the odometry.
+   * @param new_fixed_link the name of the new link that should be considered fixed
+   * @return true/false on success/failure (typically if the frame/link names are wrong)
+   */
+    virtual bool changeFixedLinkSimpleLeggedOdometry(const std::string& new_fixed_link);
+
 
     /**
      * Quit the module.

--- a/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamicsTree/wholeBodyDynamicsStatesInterface.h
+++ b/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamicsTree/wholeBodyDynamicsStatesInterface.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2013 iCub Facility - Istituto Italiano di Tecnologia
- * Author: Andrea Del Prete
- * email: andrea.delprete@iit.it
+ * Copyright (C) 2015 Robotics, Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
+ * Author: Silvio Traversaro
+ * email: silvio.traversaro@iit.it
  *
  * Permission is granted to copy, distribute, and/or modify this program
  * under the terms of the GNU General Public License, version 2 or any

--- a/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamics_IDLServer.h
+++ b/src/modules/wholeBodyDynamicsTree/include/wholeBodyDynamics_IDLServer.h
@@ -61,6 +61,21 @@ public:
    * @return true/false on success/failure
    */
   virtual bool quit();
+  /**
+   * Reset the odometry world to be (initially) a frame specified in the robot model,
+   * and specify a link that is assumed to be fixed in the odometry.
+   * @param initial_world_frame the frame of the robot model that is assume to be initially
+   *        coincident with the world/inertial frame.
+   * @param new_fixed_link the name of the link that should be initially fixed
+   * @return true/false on success/failure (typically if the frame/link names are wrong)
+   */
+  virtual bool resetSimpleLeggedOdometry(const std::string& initial_world_frame, const std::string& initial_fixed_link);
+  /**
+   * Change the link that is considered fixed by the odometry.
+   * @param new_fixed_link the name of the new link that should be considered fixed
+   * @return true/false on success/failure (typically if the frame/link names are wrong)
+   */
+  virtual bool changeFixedLinkSimpleLeggedOdometry(const std::string& new_fixed_link);
   virtual bool read(yarp::os::ConnectionReader& connection);
   virtual std::vector<std::string> help(const std::string& functionName="--all");
 };

--- a/src/modules/wholeBodyDynamicsTree/src/main.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/main.cpp
@@ -77,7 +77,25 @@ None.
 None.
 
 \section conf_file_sec Configuration Files
-None
+
+Configuration files of wholeBodyDynamicsTree load several groups,
+to separate concerns about the different functionalities of the wholeBodyDynamicsTree.
+
+### `SIMPLE_LEGGED_ODOMETRY` group
+
+  | Parameter name | Type | Units | Default Value | Required | Description | Notes |
+  |:--------------:|:------:|:-----:|:-------------:|:--------:|:-----------:|:-----:|
+  | initial_world_frame | string | - | - | Yes | Name of the frame of the model that is supposed to be coincident with the world/inertial at start | - |
+  | initial_fixed_link  | string | - | - | Yes | Name of the link that is assumed to be fixed at start |
+  | floating_base_frame  | string | - | - | Yes | Name of the frame assume to be the floating base |
+
+Consider that this values are just initialization values, but you can always
+reset/change fixed link of the simple legged odometry using the RPC port.
+
+It the odometry is correctly configured, the /${name}/floatingbasepos:o port
+will stream the 4x4 Transform matrix representing the world_H_floatingbase transform
+(i.e. the matrix that transforms position homogenous vectors expressed in the floatingbase frame to
+ vector expressed in the world frame)
 
 \section tested_os_sec Tested OS
 Linux and OS X.

--- a/src/modules/wholeBodyDynamicsTree/src/simpleLeggedOdometry.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/simpleLeggedOdometry.cpp
@@ -17,6 +17,8 @@
 
 #include "wholeBodyDynamicsTree/simpleLeggedOdometry.h"
 
+#include "kdl/frames_io.hpp"
+
 simpleLeggedOdometry::simpleLeggedOdometry():
     odometry_model(0),
     current_fixed_link_id(-1),
@@ -87,14 +89,13 @@ bool simpleLeggedOdometry::reset(const int initial_world_frame_position_index, c
 
 bool simpleLeggedOdometry::changeFixedLink(const std::string& new_fixed_link_name)
 {
-    KDL::CoDyCo::LinkMap::const_iterator link_it = odometry_model->getKDLUndirectedTree().getLink(new_fixed_link_name);
+    int new_fixed_link_id = odometry_model->getLinkIndex(new_fixed_link_name);
 
-    if( link_it ==  odometry_model->getKDLUndirectedTree().getInvalidLinkIterator() )
+    if( new_fixed_link_id < 0 )
     {
         return false;
     }
 
-    int new_fixed_link_id = link_it->getLinkIndex();
     return changeFixedLink(new_fixed_link_id);
 }
 
@@ -105,6 +106,7 @@ bool simpleLeggedOdometry::changeFixedLink(const int& new_fixed_link_id)
     KDL::Frame world_H_old_fixed = this->world_H_fixed;
     KDL::Frame old_fixed_H_new_fixed = odometry_model->getPositionKDL(old_fixed_link_id,new_fixed_link_id);
     this->world_H_fixed = world_H_old_fixed*old_fixed_H_new_fixed;
+    this->current_fixed_link_id = new_fixed_link_id;
     return true;
 }
 

--- a/src/modules/wholeBodyDynamicsTree/src/simpleLeggedOdometry.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/simpleLeggedOdometry.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2014 Fondazione Istituto Italiano di Tecnologia - Italian Institute of Technology
+ * Author: Silvio Traversaro
+ * email:  silvio.traversaro@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#include "wholeBodyDynamicsTree/simpleLeggedOdometry.h"
+
+simpleLeggedOdometry::simpleLeggedOdometry():
+    odometry_model(0),
+    current_fixed_link_id(-1),
+    world_H_fixed()
+{
+
+}
+
+simpleLeggedOdometry::~simpleLeggedOdometry()
+{
+    if( odometry_model )
+    {
+        delete odometry_model;
+        odometry_model=0;
+    }
+}
+
+bool simpleLeggedOdometry::init(KDL::CoDyCo::UndirectedTree & undirected_tree,
+                                const std::string& initial_world_frame_position,
+                                const std::string& initial_fixed_link)
+{
+    int initial_world_frame_position_index = undirected_tree.getLink(initial_world_frame_position)->getLinkIndex();
+    int initial_fixed_link_index = undirected_tree.getLink(initial_fixed_link)->getLinkIndex();;
+    if( initial_fixed_link_index < 0 ||
+        initial_world_frame_position_index < 0 )
+    {
+        return false;
+    }
+
+    return init(undirected_tree,initial_world_frame_position_index,initial_fixed_link_index);
+}
+
+bool simpleLeggedOdometry::init(KDL::CoDyCo::UndirectedTree & undirected_tree,
+                                const int initial_world_frame_position_index,
+                                const int initial_fixed_link_index)
+{
+    if( odometry_model )
+    {
+        delete odometry_model;
+        odometry_model=0;
+    }
+
+    odometry_model = new iCub::iDynTree::DynTree(undirected_tree.getTree(),undirected_tree.getSerialization());
+    bool ok = odometry_model->setFloatingBaseLink(initial_fixed_link_index);
+    ok = ok && reset(initial_world_frame_position_index,initial_fixed_link_index);
+    return ok;
+}
+
+bool simpleLeggedOdometry::reset(const std::string& initial_world_frame_position, const std::string& initial_fixed_link)
+{
+    int initial_world_frame_position_index = odometry_model->getLinkIndex(initial_world_frame_position);
+    int initial_fixed_link_index = odometry_model->getLinkIndex(initial_fixed_link);
+    if( initial_fixed_link_index < 0 ||
+        initial_world_frame_position_index < 0 )
+    {
+        return false;
+    }
+
+    return reset(initial_world_frame_position_index,initial_fixed_link_index);
+}
+
+bool simpleLeggedOdometry::reset(const int initial_world_frame_position_index, const int initial_fixed_link_index)
+{
+    current_fixed_link_id = initial_fixed_link_index;
+    world_H_fixed = odometry_model->getPositionKDL(initial_world_frame_position_index,initial_fixed_link_index);
+    return true;
+}
+
+bool simpleLeggedOdometry::changeFixedLink(const std::string& new_fixed_link_name)
+{
+    KDL::CoDyCo::LinkMap::const_iterator link_it = odometry_model->getKDLUndirectedTree().getLink(new_fixed_link_name);
+
+    if( link_it ==  odometry_model->getKDLUndirectedTree().getInvalidLinkIterator() )
+    {
+        return false;
+    }
+
+    int new_fixed_link_id = link_it->getLinkIndex();
+    return changeFixedLink(new_fixed_link_id);
+}
+
+
+bool simpleLeggedOdometry::changeFixedLink(const int& new_fixed_link_id)
+{
+    int old_fixed_link_id = this->current_fixed_link_id;
+    KDL::Frame world_H_old_fixed = this->world_H_fixed;
+    KDL::Frame old_fixed_H_new_fixed = odometry_model->getPositionKDL(old_fixed_link_id,new_fixed_link_id);
+    this->world_H_fixed = world_H_old_fixed*old_fixed_H_new_fixed;
+    return true;
+}
+
+std::string simpleLeggedOdometry::getCurrentFixedLink()
+{
+    return odometry_model->getKDLUndirectedTree().getLink(this->current_fixed_link_id)->getName();
+}
+
+iCub::iDynTree::DynTree& simpleLeggedOdometry::getDynTree()
+{
+    return *odometry_model;
+}
+
+KDL::Frame simpleLeggedOdometry::getWorldFrameTransform(const int frame_index)
+{
+    KDL::Frame fixed_H_frame = odometry_model->getPositionKDL(this->current_fixed_link_id,frame_index);
+    return this->world_H_fixed*fixed_H_frame;
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamicsModule.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamicsModule.cpp
@@ -407,6 +407,29 @@ bool wholeBodyDynamicsModule::resetOffset(const std::string& calib_code)
     }
 }
 
+bool wholeBodyDynamicsModule::resetSimpleLeggedOdometry(const std::string& initial_world_frame,
+                                                        const std::string& initial_fixed_link)
+{
+    if(wbdThread) {
+        return wbdThread->resetSimpleLeggedOdometry(initial_world_frame,initial_fixed_link);
+    } else {
+        return false;
+    }
+}
+
+
+bool wholeBodyDynamicsModule::changeFixedLinkSimpleLeggedOdometry(const std::string& new_fixed_link)
+{
+    if(wbdThread) {
+        return wbdThread->changeFixedLinkSimpleLeggedOdometry(new_fixed_link);
+    } else {
+        return false;
+    }
+}
+
+
+
+
 
 bool wholeBodyDynamicsModule::quit()
 {

--- a/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamicsThread.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamicsThread.cpp
@@ -571,7 +571,7 @@ bool wholeBodyDynamicsThread::threadInit()
     ///////////////////////////////////
     /// Odometry initialization
     ///////////////////////////////////
-
+    initOdometry();
 
     //Start with calibration
     first_calibration = true;
@@ -890,6 +890,8 @@ bool wholeBodyDynamicsThread::initOdometry()
     yInfo() << " SIMPLE_LEGGED_ODOMETRY initialized with initial world frame coincident with "
            << initial_world_frame << " and initial fixed link " << initial_fixed_link;
 
+    this->odometry_enabled = true;
+
     // Open ports
     port_floatingbase = new BufferedPort<Matrix>;
     port_floatingbase->open(string("/"+moduleName+"/floatingbasepos:o"));
@@ -974,6 +976,7 @@ bool wholeBodyDynamicsThread::changeFixedLinkSimpleLeggedOdometry(const string& 
     }
     else
     {
+        yWarning() << "SIMPLE_LEGGED_ODOMETRY is disabled, changing fixed link failed";
         ok = false;
     }
     run_mutex.unlock();
@@ -1289,6 +1292,9 @@ void wholeBodyDynamicsThread::estimation_run()
 
     //Send external wrench estimates
     publishExternalWrenches();
+
+    //Compute odometry
+    runOdometry();
 
     //Send base information to iCubGui
     publishBaseToGui();

--- a/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamics_IDLServer.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamics_IDLServer.cpp
@@ -63,6 +63,25 @@ public:
   virtual bool read(yarp::os::ConnectionReader& connection);
 };
 
+class wholeBodyDynamics_IDLServer_resetSimpleLeggedOdometry : public yarp::os::Portable {
+public:
+  std::string initial_world_frame;
+  std::string initial_fixed_link;
+  bool _return;
+  void init(const std::string& initial_world_frame, const std::string& initial_fixed_link);
+  virtual bool write(yarp::os::ConnectionWriter& connection);
+  virtual bool read(yarp::os::ConnectionReader& connection);
+};
+
+class wholeBodyDynamics_IDLServer_changeFixedLinkSimpleLeggedOdometry : public yarp::os::Portable {
+public:
+  std::string new_fixed_link;
+  bool _return;
+  void init(const std::string& new_fixed_link);
+  virtual bool write(yarp::os::ConnectionWriter& connection);
+  virtual bool read(yarp::os::ConnectionReader& connection);
+};
+
 bool wholeBodyDynamics_IDLServer_calib::write(yarp::os::ConnectionWriter& connection) {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(3)) return false;
@@ -207,6 +226,54 @@ void wholeBodyDynamics_IDLServer_quit::init() {
   _return = false;
 }
 
+bool wholeBodyDynamics_IDLServer_resetSimpleLeggedOdometry::write(yarp::os::ConnectionWriter& connection) {
+  yarp::os::idl::WireWriter writer(connection);
+  if (!writer.writeListHeader(3)) return false;
+  if (!writer.writeTag("resetSimpleLeggedOdometry",1,1)) return false;
+  if (!writer.writeString(initial_world_frame)) return false;
+  if (!writer.writeString(initial_fixed_link)) return false;
+  return true;
+}
+
+bool wholeBodyDynamics_IDLServer_resetSimpleLeggedOdometry::read(yarp::os::ConnectionReader& connection) {
+  yarp::os::idl::WireReader reader(connection);
+  if (!reader.readListReturn()) return false;
+  if (!reader.readBool(_return)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+
+void wholeBodyDynamics_IDLServer_resetSimpleLeggedOdometry::init(const std::string& initial_world_frame, const std::string& initial_fixed_link) {
+  _return = false;
+  this->initial_world_frame = initial_world_frame;
+  this->initial_fixed_link = initial_fixed_link;
+}
+
+bool wholeBodyDynamics_IDLServer_changeFixedLinkSimpleLeggedOdometry::write(yarp::os::ConnectionWriter& connection) {
+  yarp::os::idl::WireWriter writer(connection);
+  if (!writer.writeListHeader(2)) return false;
+  if (!writer.writeTag("changeFixedLinkSimpleLeggedOdometry",1,1)) return false;
+  if (!writer.writeString(new_fixed_link)) return false;
+  return true;
+}
+
+bool wholeBodyDynamics_IDLServer_changeFixedLinkSimpleLeggedOdometry::read(yarp::os::ConnectionReader& connection) {
+  yarp::os::idl::WireReader reader(connection);
+  if (!reader.readListReturn()) return false;
+  if (!reader.readBool(_return)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+
+void wholeBodyDynamics_IDLServer_changeFixedLinkSimpleLeggedOdometry::init(const std::string& new_fixed_link) {
+  _return = false;
+  this->new_fixed_link = new_fixed_link;
+}
+
 wholeBodyDynamics_IDLServer::wholeBodyDynamics_IDLServer() {
   yarp().setOwner(*this);
 }
@@ -266,6 +333,26 @@ bool wholeBodyDynamics_IDLServer::quit() {
   helper.init();
   if (!yarp().canWrite()) {
     fprintf(stderr,"Missing server method '%s'?\n","bool wholeBodyDynamics_IDLServer::quit()");
+  }
+  bool ok = yarp().write(helper,helper);
+  return ok?helper._return:_return;
+}
+bool wholeBodyDynamics_IDLServer::resetSimpleLeggedOdometry(const std::string& initial_world_frame, const std::string& initial_fixed_link) {
+  bool _return = false;
+  wholeBodyDynamics_IDLServer_resetSimpleLeggedOdometry helper;
+  helper.init(initial_world_frame,initial_fixed_link);
+  if (!yarp().canWrite()) {
+    fprintf(stderr,"Missing server method '%s'?\n","bool wholeBodyDynamics_IDLServer::resetSimpleLeggedOdometry(const std::string& initial_world_frame, const std::string& initial_fixed_link)");
+  }
+  bool ok = yarp().write(helper,helper);
+  return ok?helper._return:_return;
+}
+bool wholeBodyDynamics_IDLServer::changeFixedLinkSimpleLeggedOdometry(const std::string& new_fixed_link) {
+  bool _return = false;
+  wholeBodyDynamics_IDLServer_changeFixedLinkSimpleLeggedOdometry helper;
+  helper.init(new_fixed_link);
+  if (!yarp().canWrite()) {
+    fprintf(stderr,"Missing server method '%s'?\n","bool wholeBodyDynamics_IDLServer::changeFixedLinkSimpleLeggedOdometry(const std::string& new_fixed_link)");
   }
   bool ok = yarp().write(helper,helper);
   return ok?helper._return:_return;
@@ -387,6 +474,43 @@ bool wholeBodyDynamics_IDLServer::read(yarp::os::ConnectionReader& connection) {
       reader.accept();
       return true;
     }
+    if (tag == "resetSimpleLeggedOdometry") {
+      std::string initial_world_frame;
+      std::string initial_fixed_link;
+      if (!reader.readString(initial_world_frame)) {
+        reader.fail();
+        return false;
+      }
+      if (!reader.readString(initial_fixed_link)) {
+        reader.fail();
+        return false;
+      }
+      bool _return;
+      _return = resetSimpleLeggedOdometry(initial_world_frame,initial_fixed_link);
+      yarp::os::idl::WireWriter writer(reader);
+      if (!writer.isNull()) {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeBool(_return)) return false;
+      }
+      reader.accept();
+      return true;
+    }
+    if (tag == "changeFixedLinkSimpleLeggedOdometry") {
+      std::string new_fixed_link;
+      if (!reader.readString(new_fixed_link)) {
+        reader.fail();
+        return false;
+      }
+      bool _return;
+      _return = changeFixedLinkSimpleLeggedOdometry(new_fixed_link);
+      yarp::os::idl::WireWriter writer(reader);
+      if (!writer.isNull()) {
+        if (!writer.writeListHeader(1)) return false;
+        if (!writer.writeBool(_return)) return false;
+      }
+      reader.accept();
+      return true;
+    }
     if (tag == "help") {
       std::string functionName;
       if (!reader.readString(functionName)) {
@@ -427,6 +551,8 @@ std::vector<std::string> wholeBodyDynamics_IDLServer::help(const std::string& fu
     helpString.push_back("calibStandingRightFoot");
     helpString.push_back("resetOffset");
     helpString.push_back("quit");
+    helpString.push_back("resetSimpleLeggedOdometry");
+    helpString.push_back("changeFixedLinkSimpleLeggedOdometry");
     helpString.push_back("help");
   }
   else {
@@ -473,6 +599,21 @@ std::vector<std::string> wholeBodyDynamics_IDLServer::help(const std::string& fu
       helpString.push_back("bool quit() ");
       helpString.push_back("Quit the module. ");
       helpString.push_back("@return true/false on success/failure ");
+    }
+    if (functionName=="resetSimpleLeggedOdometry") {
+      helpString.push_back("bool resetSimpleLeggedOdometry(const std::string& initial_world_frame, const std::string& initial_fixed_link) ");
+      helpString.push_back("Reset the odometry world to be (initially) a frame specified in the robot model, ");
+      helpString.push_back("and specify a link that is assumed to be fixed in the odometry. ");
+      helpString.push_back("@param initial_world_frame the frame of the robot model that is assume to be initially ");
+      helpString.push_back("       coincident with the world/inertial frame. ");
+      helpString.push_back("@param new_fixed_link the name of the link that should be initially fixed ");
+      helpString.push_back("@return true/false on success/failure (typically if the frame/link names are wrong) ");
+    }
+    if (functionName=="changeFixedLinkSimpleLeggedOdometry") {
+      helpString.push_back("bool changeFixedLinkSimpleLeggedOdometry(const std::string& new_fixed_link) ");
+      helpString.push_back("Change the link that is considered fixed by the odometry. ");
+      helpString.push_back("@param new_fixed_link the name of the new link that should be considered fixed ");
+      helpString.push_back("@return true/false on success/failure (typically if the frame/link names are wrong) ");
     }
     if (functionName=="help") {
       helpString.push_back("std::vector<std::string> help(const std::string& functionName=\"--all\")");

--- a/src/modules/wholeBodyDynamicsTree/wholeBodyDynamics.thrift
+++ b/src/modules/wholeBodyDynamicsTree/wholeBodyDynamics.thrift
@@ -57,4 +57,32 @@ service wholeBodyDynamics_IDLServer
   * @return true/false on success/failure
   */
   bool quit();
+
+  // This should be implemented in a separated "simpleLeggedOdometry" interface,
+  // but for the time being it is easier to just implement it here
+  //service simpleLeggedOdometry_IDLServer
+  // {
+
+  /**
+   * Reset the odometry world to be (initially) a frame specified in the robot model,
+   * and specify a link that is assumed to be fixed in the odometry.
+   * @param initial_world_frame the frame of the robot model that is assume to be initially
+   *        coincident with the world/inertial frame.
+   * @param new_fixed_link the name of the link that should be initially fixed
+   * @return true/false on success/failure (typically if the frame/link names are wrong)
+   */
+  bool resetSimpleLeggedOdometry(1:string initial_world_frame, 2:string initial_fixed_link)
+
+  /**
+   * Change the link that is considered fixed by the odometry. 
+   * @param new_fixed_link the name of the new link that should be considered fixed
+   * @return true/false on success/failure (typically if the frame/link names are wrong)
+   */
+  bool changeFixedLinkSimpleLeggedOdometry(1:string new_fixed_link)
+
+  // } /** simpleLeggedOdometry_IDLServer */
 }
+
+
+
+


### PR DESCRIPTION
Adding a basic version of legged odometry in wholeBodyDynamicsTree . 

The computational part of it is self-contained in the simpleLeggedOdometry class, so if necessary a self-contained "odometry" module can be easily coded. 

The monitor logic on which link should be considered "fixed" is not included (mainly because I was afraid that any sensor based logic would be not so robust) and this information is provided on the rpc port (the idea for the `graspAndStep` demo is that the demo coordinator will provide this information, based on its state). 