### PR TITLE
[wholeBodyDynamicsTree] Fix not initialized flags if SIMPLE_LEGGED_ODMETRY was not present in options

### DIFF
--- a/src/modules/wholeBodyDynamicsTree/app/robots/iCubGenova02/wholeBodyDynamicsTree.ini
+++ b/src/modules/wholeBodyDynamicsTree/app/robots/iCubGenova02/wholeBodyDynamicsTree.ini
@@ -76,9 +76,3 @@ left_foot_subtree   = ((l_foot),l_foot)
 right_foot_subtree  = ((r_foot),r_foot)
 left_arm_subtree   = ((l_upper_arm,l_elbow_1),l_elbow_1)
 right_arm_subtree   = ((r_upper_arm,r_elbow_1),r_elbow_1)
-
-# Options for simple legged odometry
-[SIMPLE_LEGGED_ODOMETRY]
-initial_world_frame l_sole
-initial_fixed_link  l_foot
-floating_base_frame root_link

--- a/src/modules/wholeBodyDynamicsTree/app/robots/icubGazeboSim/wholeBodyDynamicsTree.ini
+++ b/src/modules/wholeBodyDynamicsTree/app/robots/icubGazeboSim/wholeBodyDynamicsTree.ini
@@ -80,11 +80,3 @@ left_foot_subtree   = ((l_foot),l_foot)
 right_foot_subtree  = ((r_foot),r_foot)
 left_arm_subtree   = ((l_upper_arm,l_elbow_1,l_forearm,l_wrist_1,l_hand),l_hand)
 right_arm_subtree   = ((r_upper_arm,r_elbow_1,r_forearm,r_wrist_1,r_hand),r_hand)
-
-# Options for simple legged odometry
-[SIMPLE_LEGGED_ODOMETRY]
-initial_world_frame codyco_balancing_world
-initial_fixed_link  l_foot
-floating_base_frame root_link
-stream_com
-additional_frames (root_link l_sole r_sole)

--- a/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamicsThread.cpp
+++ b/src/modules/wholeBodyDynamicsTree/src/wholeBodyDynamicsThread.cpp
@@ -946,6 +946,8 @@ bool wholeBodyDynamicsThread::initOdometry()
     {
         yInfo() << " SIMPLE_LEGGED_ODOMETRY group not found, odometry disabled";
         this->odometry_enabled = false;
+        this->com_streaming_enabled = false;
+        this->frames_streaming_enabled = false;
         return true;
     }
 
@@ -958,6 +960,8 @@ bool wholeBodyDynamicsThread::initOdometry()
     {
         yError() << " SIMPLE_LEGGED_ODOMETRY group found but malformed, exiting";
         this->odometry_enabled = false;
+        this->com_streaming_enabled = false;
+        this->frames_streaming_enabled = false;
         return false;
     }
 
@@ -998,6 +1002,9 @@ bool wholeBodyDynamicsThread::initOdometry()
     if( !ok )
     {
         yError() << "Odometry initialization failed, please check your parameters";
+        this->odometry_enabled = false;
+        this->com_streaming_enabled = false;
+        this->frames_streaming_enabled = false;
         return false;
     }
 


### PR DESCRIPTION
Also, update configuration file of iCubGenova02 and icubGazeboSim to not include
the SIMPLE_LEGGED_ODOMETRY group. The SIMPLE_LEGGED_ODOMETRY was an hack for the codyco second year
demo, and the proper functionality will be implemented in the new wholeBodyEstimator module.
The wbi needs to be configured with the externalFloatingBaseStatePort option to read the port,
and no robot has that flag in their wbi configuration.

Fix https://github.com/robotology/codyco-modules/issues/159 . 
