### PR TITLE
Add head_zero position for the eyes to icubGazeboSim

### DIFF
--- a/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingTwoFeet.ini
@@ -5,8 +5,8 @@ parts (head torso left_arm right_arm right_leg left_leg)
  
 [head_zero]    
 //                          0             1             2            
-PositionZero                0             0             0                      
-VelocityZero                10            10            10                     
+PositionZero                0             0             0       	0				0			0              
+VelocityZero                10            10            10       	10				10			10              
 
 [torso_zero]   
 //                          0             1             2              


### PR DESCRIPTION
Now, the icubGazeboSim has eyes, so in the homePoseBalancingTwoFeet.ini file, we add the information of the positionzero/velocityzero of these eyes.