### PR TITLE
Fix hard coded imu frame in wholebodydynamics device

### DIFF
--- a/src/devices/floatingBaseEstimator/floatingBaseEstimator.cpp
+++ b/src/devices/floatingBaseEstimator/floatingBaseEstimator.cpp
@@ -238,7 +238,11 @@ bool floatingBaseEstimator::open(os::Searchable& config)
 
     // Open the controlboard remapper
     ok = this->openRemapperControlBoard(config);
-    if( !ok ) return false;
+    if( !ok )
+    {
+        closePorts();
+        return false;
+    }
 
     return true;
 }

--- a/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -600,6 +600,17 @@ bool WholeBodyDynamicsDevice::loadSettingsFromConfig(os::Searchable& config)
         settings.fixedFrameName = fixedFrameName;
     }
 
+    // Check for the imu frame
+    if( prop.check("imuFrameName") &&
+        prop.find("imuFrameName").isString() )
+    {
+        settings.imuFrameName = prop.find("imuFrameName").asString();
+    }
+    else
+    {
+        yError() << "wholeBodyDynamics : missing required string parameter imuFrameName";
+        return false;
+    }
 
     // fixedFrameGravity is always required even if you
     // use the IMU because the estimation could switch in use a fixed frame
@@ -1210,7 +1221,7 @@ void WholeBodyDynamicsDevice::updateKinematics()
     if( settings.kinematicSource == IMU )
     {
         // Hardcode for the meanwhile
-        iDynTree::FrameIndex imuFrameIndex = estimator.model().getFrameIndex("imu_frame");
+        iDynTree::FrameIndex imuFrameIndex = estimator.model().getFrameIndex(settings.imuFrameName);
 
         estimator.updateKinematicsFromFloatingBase(jointPos,jointVel,jointAcc,imuFrameIndex,
                                                    filteredIMUMeasurements.linProperAcc,filteredIMUMeasurements.angularVel,filteredIMUMeasurements.angularAcc);
@@ -1378,9 +1389,6 @@ void WholeBodyDynamicsDevice::publishEstimatedQuantities()
             // Send gravity compensation torques
             publishGravityCompensation();
 
-            //Send base information to iCubGui
-            //publishBaseToGui();
-
             //Send filtered inertia for gravity compensation
             //publishFilteredInertialForGravityCompensator();
 
@@ -1452,8 +1460,6 @@ void WholeBodyDynamicsDevice::resetGravityCompensation()
         }
     }
 }
-
-
 
 template <class T> void broadcastData(T& _values, yarp::os::BufferedPort<T>& _port)
 {

--- a/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -119,6 +119,7 @@ class wholeBodyDynamicsDeviceFilters
  * | modelFile      |      -         | path to file      |   -   | model.urdf    | No       | Path to the URDF file used for the kinematic and dynamic model.   |       |
  * | assumeFixed    |                | frame name        |   -   |     -         | No       | If it is present, the initial kinematic source used for estimation will be that specified frame is fixed, and its gravity is specified by fixedFrameGravity. Otherwise, the default IMU will be used. | |
  * | fixedFrameGravity  |      -     | vector of doubles | m/s^2 | -             | Yes      | Gravity of the frame that is assumed to be fixed, if the kinematic source used is the fixed frame. | |
+ * | imuFrameName   |       -        | string            |   -   |      -        | Yes      | Name of the frame (in the robot model) with respect to which the IMU broadcast its sensor measurements. |
  * | imuFilterCutoffInHz |     -     | double            | Hz    |      -        | Yes      | Cutoff frequency of the filter used to filter IMU measures. | The used filter is a simple first order filter. |
  * | forceTorqueFilterCutoffInHz | - | double            | Hz    |      -        | Yes      | Cutoff frequency of the filter used to filter FT measures.  |  The used filter is a simple first order filter. |
  * | jointVelFilterCutoffInHz    | - | double            | Hz    |      -        | Yes      | Cutoff frequency of the filter used to filter joint velocities measures. | The used filter is a simple first order filter. |
@@ -204,7 +205,7 @@ class wholeBodyDynamicsDeviceFilters
  *         <param name="modelFile">model.urdf</param>
  *         <param name="fixedFrameGravity">(0,0,-9.81)</param>
  *         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
- *
+ *         <param name="imuFrameName">imu_frame</param>
  *         <!-- map between iDynTree links (identified by a name)
  *              and skinDynLib links (identified by their frame name, a BodyPart enum
  *              and a local (to the body part) index -->
@@ -284,8 +285,8 @@ private:
     bool correctlyConfigured;
 
     /**
-     *
-     *
+     * True if sensors have been read correctly, false
+     * if sensors have never been read or if one of the sensor devices returned an error (such as a timeout).
      */
     bool sensorReadCorrectly;
 
@@ -325,7 +326,6 @@ private:
         yarp::dev::IVirtualAnalogSensor * ivirtsens;
         yarp::dev::IMultipleWrapper     * multwrap;
     } remappedVirtualAnalogSensorsInterfaces;
-
 
     /** F/T sensors interfaces */
     std::vector<yarp::dev::IAnalogSensor * > ftSensors;

--- a/src/devices/wholeBodyDynamics/wholebodydynamics.xml
+++ b/src/devices/wholeBodyDynamics/wholebodydynamics.xml
@@ -7,6 +7,7 @@
         <param name="modelFile">model.urdf</param>
         <param name="fixedFrameGravity">(0,0,-9.81)</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
+        <param name="imuFrameName">imu_frame<param>
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/src/idl/wholeBodyDynamicsSettings/autogenerated/include/wholeBodyDynamicsSettings.h
+++ b/src/idl/wholeBodyDynamicsSettings/autogenerated/include/wholeBodyDynamicsSettings.h
@@ -27,6 +27,10 @@ public:
   /**
    * If kinematicSource is FIXED_LINK, specify the gravity vector (in m/s^2) in the fixedFrame
    */
+  std::string imuFrameName;
+  /**
+   * If kinematicSource is IMU, specify the frame name of the imu
+   */
   double imuFilterCutoffInHz;
   /**
    * Cutoff frequency (in Hz) of the first order filter of the IMU
@@ -50,11 +54,11 @@ public:
   bool useJointAcceleration;
 
   // Default constructor
-  wholeBodyDynamicsSettings() : kinematicSource((KinematicSourceType)0), fixedFrameName(""), imuFilterCutoffInHz(0), forceTorqueFilterCutoffInHz(0), jointVelFilterCutoffInHz(0), jointAccFilterCutoffInHz(0), useJointVelocity(0), useJointAcceleration(0) {
+  wholeBodyDynamicsSettings() : kinematicSource((KinematicSourceType)0), fixedFrameName(""), imuFrameName(""), imuFilterCutoffInHz(0), forceTorqueFilterCutoffInHz(0), jointVelFilterCutoffInHz(0), jointAccFilterCutoffInHz(0), useJointVelocity(0), useJointAcceleration(0) {
   }
 
   // Constructor with field values
-  wholeBodyDynamicsSettings(const KinematicSourceType kinematicSource,const std::string& fixedFrameName,const Gravity& fixedFrameGravity,const double imuFilterCutoffInHz,const double forceTorqueFilterCutoffInHz,const double jointVelFilterCutoffInHz,const double jointAccFilterCutoffInHz,const bool useJointVelocity,const bool useJointAcceleration) : kinematicSource(kinematicSource), fixedFrameName(fixedFrameName), fixedFrameGravity(fixedFrameGravity), imuFilterCutoffInHz(imuFilterCutoffInHz), forceTorqueFilterCutoffInHz(forceTorqueFilterCutoffInHz), jointVelFilterCutoffInHz(jointVelFilterCutoffInHz), jointAccFilterCutoffInHz(jointAccFilterCutoffInHz), useJointVelocity(useJointVelocity), useJointAcceleration(useJointAcceleration) {
+  wholeBodyDynamicsSettings(const KinematicSourceType kinematicSource,const std::string& fixedFrameName,const Gravity& fixedFrameGravity,const std::string& imuFrameName,const double imuFilterCutoffInHz,const double forceTorqueFilterCutoffInHz,const double jointVelFilterCutoffInHz,const double jointAccFilterCutoffInHz,const bool useJointVelocity,const bool useJointAcceleration) : kinematicSource(kinematicSource), fixedFrameName(fixedFrameName), fixedFrameGravity(fixedFrameGravity), imuFrameName(imuFrameName), imuFilterCutoffInHz(imuFilterCutoffInHz), forceTorqueFilterCutoffInHz(forceTorqueFilterCutoffInHz), jointVelFilterCutoffInHz(jointVelFilterCutoffInHz), jointAccFilterCutoffInHz(jointAccFilterCutoffInHz), useJointVelocity(useJointVelocity), useJointAcceleration(useJointAcceleration) {
   }
 
   // Copy constructor
@@ -62,6 +66,7 @@ public:
     this->kinematicSource = __alt.kinematicSource;
     this->fixedFrameName = __alt.fixedFrameName;
     this->fixedFrameGravity = __alt.fixedFrameGravity;
+    this->imuFrameName = __alt.imuFrameName;
     this->imuFilterCutoffInHz = __alt.imuFilterCutoffInHz;
     this->forceTorqueFilterCutoffInHz = __alt.forceTorqueFilterCutoffInHz;
     this->jointVelFilterCutoffInHz = __alt.jointVelFilterCutoffInHz;
@@ -75,6 +80,7 @@ public:
     this->kinematicSource = __alt.kinematicSource;
     this->fixedFrameName = __alt.fixedFrameName;
     this->fixedFrameGravity = __alt.fixedFrameGravity;
+    this->imuFrameName = __alt.imuFrameName;
     this->imuFilterCutoffInHz = __alt.imuFilterCutoffInHz;
     this->forceTorqueFilterCutoffInHz = __alt.forceTorqueFilterCutoffInHz;
     this->jointVelFilterCutoffInHz = __alt.jointVelFilterCutoffInHz;
@@ -97,6 +103,8 @@ private:
   bool nested_write_fixedFrameName(yarp::os::idl::WireWriter& writer);
   bool write_fixedFrameGravity(yarp::os::idl::WireWriter& writer);
   bool nested_write_fixedFrameGravity(yarp::os::idl::WireWriter& writer);
+  bool write_imuFrameName(yarp::os::idl::WireWriter& writer);
+  bool nested_write_imuFrameName(yarp::os::idl::WireWriter& writer);
   bool write_imuFilterCutoffInHz(yarp::os::idl::WireWriter& writer);
   bool nested_write_imuFilterCutoffInHz(yarp::os::idl::WireWriter& writer);
   bool write_forceTorqueFilterCutoffInHz(yarp::os::idl::WireWriter& writer);
@@ -115,6 +123,8 @@ private:
   bool nested_read_fixedFrameName(yarp::os::idl::WireReader& reader);
   bool read_fixedFrameGravity(yarp::os::idl::WireReader& reader);
   bool nested_read_fixedFrameGravity(yarp::os::idl::WireReader& reader);
+  bool read_imuFrameName(yarp::os::idl::WireReader& reader);
+  bool nested_read_imuFrameName(yarp::os::idl::WireReader& reader);
   bool read_imuFilterCutoffInHz(yarp::os::idl::WireReader& reader);
   bool nested_read_imuFilterCutoffInHz(yarp::os::idl::WireReader& reader);
   bool read_forceTorqueFilterCutoffInHz(yarp::os::idl::WireReader& reader);
@@ -198,6 +208,13 @@ public:
       communicate();
       did_set_fixedFrameGravity();
     }
+    void set_imuFrameName(const std::string& imuFrameName) {
+      will_set_imuFrameName();
+      obj->imuFrameName = imuFrameName;
+      mark_dirty_imuFrameName();
+      communicate();
+      did_set_imuFrameName();
+    }
     void set_imuFilterCutoffInHz(const double imuFilterCutoffInHz) {
       will_set_imuFilterCutoffInHz();
       obj->imuFilterCutoffInHz = imuFilterCutoffInHz;
@@ -249,6 +266,9 @@ public:
     const Gravity& get_fixedFrameGravity() {
       return obj->fixedFrameGravity;
     }
+    const std::string& get_imuFrameName() {
+      return obj->imuFrameName;
+    }
     double get_imuFilterCutoffInHz() {
       return obj->imuFilterCutoffInHz;
     }
@@ -270,6 +290,7 @@ public:
     virtual bool will_set_kinematicSource() { return true; }
     virtual bool will_set_fixedFrameName() { return true; }
     virtual bool will_set_fixedFrameGravity() { return true; }
+    virtual bool will_set_imuFrameName() { return true; }
     virtual bool will_set_imuFilterCutoffInHz() { return true; }
     virtual bool will_set_forceTorqueFilterCutoffInHz() { return true; }
     virtual bool will_set_jointVelFilterCutoffInHz() { return true; }
@@ -279,6 +300,7 @@ public:
     virtual bool did_set_kinematicSource() { return true; }
     virtual bool did_set_fixedFrameName() { return true; }
     virtual bool did_set_fixedFrameGravity() { return true; }
+    virtual bool did_set_imuFrameName() { return true; }
     virtual bool did_set_imuFilterCutoffInHz() { return true; }
     virtual bool did_set_forceTorqueFilterCutoffInHz() { return true; }
     virtual bool did_set_jointVelFilterCutoffInHz() { return true; }
@@ -325,6 +347,12 @@ public:
       is_dirty_fixedFrameGravity = true;
       mark_dirty();
     }
+    void mark_dirty_imuFrameName() {
+      if (is_dirty_imuFrameName) return;
+      dirty_count++;
+      is_dirty_imuFrameName = true;
+      mark_dirty();
+    }
     void mark_dirty_imuFilterCutoffInHz() {
       if (is_dirty_imuFilterCutoffInHz) return;
       dirty_count++;
@@ -366,19 +394,21 @@ public:
       is_dirty_kinematicSource = flag;
       is_dirty_fixedFrameName = flag;
       is_dirty_fixedFrameGravity = flag;
+      is_dirty_imuFrameName = flag;
       is_dirty_imuFilterCutoffInHz = flag;
       is_dirty_forceTorqueFilterCutoffInHz = flag;
       is_dirty_jointVelFilterCutoffInHz = flag;
       is_dirty_jointAccFilterCutoffInHz = flag;
       is_dirty_useJointVelocity = flag;
       is_dirty_useJointAcceleration = flag;
-      dirty_count = flag ? 9 : 0;
+      dirty_count = flag ? 10 : 0;
     }
     bool is_dirty;
     int dirty_count;
     bool is_dirty_kinematicSource;
     bool is_dirty_fixedFrameName;
     bool is_dirty_fixedFrameGravity;
+    bool is_dirty_imuFrameName;
     bool is_dirty_imuFilterCutoffInHz;
     bool is_dirty_forceTorqueFilterCutoffInHz;
     bool is_dirty_jointVelFilterCutoffInHz;

--- a/src/idl/wholeBodyDynamicsSettings/autogenerated/src/wholeBodyDynamicsSettings.cpp
+++ b/src/idl/wholeBodyDynamicsSettings/autogenerated/src/wholeBodyDynamicsSettings.cpp
@@ -53,6 +53,20 @@ bool wholeBodyDynamicsSettings::nested_read_fixedFrameGravity(yarp::os::idl::Wir
   }
   return true;
 }
+bool wholeBodyDynamicsSettings::read_imuFrameName(yarp::os::idl::WireReader& reader) {
+  if (!reader.readString(imuFrameName)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
+bool wholeBodyDynamicsSettings::nested_read_imuFrameName(yarp::os::idl::WireReader& reader) {
+  if (!reader.readString(imuFrameName)) {
+    reader.fail();
+    return false;
+  }
+  return true;
+}
 bool wholeBodyDynamicsSettings::read_imuFilterCutoffInHz(yarp::os::idl::WireReader& reader) {
   if (!reader.readDouble(imuFilterCutoffInHz)) {
     reader.fail();
@@ -141,6 +155,7 @@ bool wholeBodyDynamicsSettings::read(yarp::os::idl::WireReader& reader) {
   if (!read_kinematicSource(reader)) return false;
   if (!read_fixedFrameName(reader)) return false;
   if (!read_fixedFrameGravity(reader)) return false;
+  if (!read_imuFrameName(reader)) return false;
   if (!read_imuFilterCutoffInHz(reader)) return false;
   if (!read_forceTorqueFilterCutoffInHz(reader)) return false;
   if (!read_jointVelFilterCutoffInHz(reader)) return false;
@@ -152,7 +167,7 @@ bool wholeBodyDynamicsSettings::read(yarp::os::idl::WireReader& reader) {
 
 bool wholeBodyDynamicsSettings::read(yarp::os::ConnectionReader& connection) {
   yarp::os::idl::WireReader reader(connection);
-  if (!reader.readListHeader(11)) return false;
+  if (!reader.readListHeader(12)) return false;
   return read(reader);
 }
 
@@ -178,6 +193,14 @@ bool wholeBodyDynamicsSettings::write_fixedFrameGravity(yarp::os::idl::WireWrite
 }
 bool wholeBodyDynamicsSettings::nested_write_fixedFrameGravity(yarp::os::idl::WireWriter& writer) {
   if (!writer.writeNested(fixedFrameGravity)) return false;
+  return true;
+}
+bool wholeBodyDynamicsSettings::write_imuFrameName(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeString(imuFrameName)) return false;
+  return true;
+}
+bool wholeBodyDynamicsSettings::nested_write_imuFrameName(yarp::os::idl::WireWriter& writer) {
+  if (!writer.writeString(imuFrameName)) return false;
   return true;
 }
 bool wholeBodyDynamicsSettings::write_imuFilterCutoffInHz(yarp::os::idl::WireWriter& writer) {
@@ -232,6 +255,7 @@ bool wholeBodyDynamicsSettings::write(yarp::os::idl::WireWriter& writer) {
   if (!write_kinematicSource(writer)) return false;
   if (!write_fixedFrameName(writer)) return false;
   if (!write_fixedFrameGravity(writer)) return false;
+  if (!write_imuFrameName(writer)) return false;
   if (!write_imuFilterCutoffInHz(writer)) return false;
   if (!write_forceTorqueFilterCutoffInHz(writer)) return false;
   if (!write_jointVelFilterCutoffInHz(writer)) return false;
@@ -243,7 +267,7 @@ bool wholeBodyDynamicsSettings::write(yarp::os::idl::WireWriter& writer) {
 
 bool wholeBodyDynamicsSettings::write(yarp::os::ConnectionWriter& connection) {
   yarp::os::idl::WireWriter writer(connection);
-  if (!writer.writeListHeader(11)) return false;
+  if (!writer.writeListHeader(12)) return false;
   return write(writer);
 }
 bool wholeBodyDynamicsSettings::Editor::write(yarp::os::ConnectionWriter& connection) {
@@ -268,6 +292,12 @@ bool wholeBodyDynamicsSettings::Editor::write(yarp::os::ConnectionWriter& connec
     if (!writer.writeString("set")) return false;
     if (!writer.writeString("fixedFrameGravity")) return false;
     if (!obj->nested_write_fixedFrameGravity(writer)) return false;
+  }
+  if (is_dirty_imuFrameName) {
+    if (!writer.writeListHeader(3)) return false;
+    if (!writer.writeString("set")) return false;
+    if (!writer.writeString("imuFrameName")) return false;
+    if (!obj->nested_write_imuFrameName(writer)) return false;
   }
   if (is_dirty_imuFilterCutoffInHz) {
     if (!writer.writeListHeader(3)) return false;
@@ -344,10 +374,15 @@ bool wholeBodyDynamicsSettings::Editor::read(yarp::os::ConnectionReader& connect
         if (!writer.writeString("Gravity fixedFrameGravity")) return false;
         if (!writer.writeString("If kinematicSource is FIXED_LINK, specify the frame of the robot that we know to be fixed (i.e. not moving with respect to an inertial frame)")) return false;
       }
+      if (field=="imuFrameName") {
+        if (!writer.writeListHeader(2)) return false;
+        if (!writer.writeString("std::string imuFrameName")) return false;
+        if (!writer.writeString("If kinematicSource is FIXED_LINK, specify the gravity vector (in m/s^2) in the fixedFrame")) return false;
+      }
       if (field=="imuFilterCutoffInHz") {
         if (!writer.writeListHeader(2)) return false;
         if (!writer.writeString("double imuFilterCutoffInHz")) return false;
-        if (!writer.writeString("If kinematicSource is FIXED_LINK, specify the gravity vector (in m/s^2) in the fixedFrame")) return false;
+        if (!writer.writeString("If kinematicSource is IMU, specify the frame name of the imu")) return false;
       }
       if (field=="forceTorqueFilterCutoffInHz") {
         if (!writer.writeListHeader(2)) return false;
@@ -375,11 +410,12 @@ bool wholeBodyDynamicsSettings::Editor::read(yarp::os::ConnectionReader& connect
         if (!writer.writeString("Use the joint velocity measurement if this is true, assume they are zero otherwise.")) return false;
       }
     }
-    if (!writer.writeListHeader(10)) return false;
+    if (!writer.writeListHeader(11)) return false;
     writer.writeString("*** Available fields:");
     writer.writeString("kinematicSource");
     writer.writeString("fixedFrameName");
     writer.writeString("fixedFrameGravity");
+    writer.writeString("imuFrameName");
     writer.writeString("imuFilterCutoffInHz");
     writer.writeString("forceTorqueFilterCutoffInHz");
     writer.writeString("jointVelFilterCutoffInHz");
@@ -419,6 +455,10 @@ bool wholeBodyDynamicsSettings::Editor::read(yarp::os::ConnectionReader& connect
       will_set_fixedFrameGravity();
       if (!obj->nested_read_fixedFrameGravity(reader)) return false;
       did_set_fixedFrameGravity();
+    } else if (key == "imuFrameName") {
+      will_set_imuFrameName();
+      if (!obj->nested_read_imuFrameName(reader)) return false;
+      did_set_imuFrameName();
     } else if (key == "imuFilterCutoffInHz") {
       will_set_imuFilterCutoffInHz();
       if (!obj->nested_read_imuFilterCutoffInHz(reader)) return false;

--- a/src/idl/wholeBodyDynamicsSettings/wholeBodyDynamicsSettings.thrift
+++ b/src/idl/wholeBodyDynamicsSettings/wholeBodyDynamicsSettings.thrift
@@ -19,10 +19,11 @@ struct wholeBodyDynamicsSettings {
     1: KinematicSourceType kinematicSource; /** Specify the source of the kinematic information for one link, see KinematicSourceType information for more info. */
     2: string fixedFrameName; /** If kinematicSource is FIXED_LINK, specify the frame of the robot that we know to be fixed (i.e. not moving with respect to an inertial frame) */
     3: Gravity fixedFrameGravity; /** If kinematicSource is FIXED_LINK, specify the gravity vector (in m/s^2) in the fixedFrame */
-    4: double imuFilterCutoffInHz; /** Cutoff frequency (in Hz) of the first order filter of the IMU */
-    5: double forceTorqueFilterCutoffInHz; /** Cutoff frequency(in Hz) of the first order filter of the F/T sensors */
-    6: double jointVelFilterCutoffInHz;    /** Cutoff frequency(in Hz) of the first order filter of the joint velocities */
-    7: double jointAccFilterCutoffInHz;    /** Cutoff frequency(in Hz) of the first order filter of the joint accelerations */
-    8: bool useJointVelocity; /** Use the joint velocity measurement if this is true, assume they are zero otherwise. */
-    9: bool useJointAcceleration; /** Use the joint acceleration measurment if this is true, assume they are zero otherwise. */
+    4: string imuFrameName; /** If kinematicSource is IMU, specify the frame name of the imu */
+    5: double imuFilterCutoffInHz; /** Cutoff frequency (in Hz) of the first order filter of the IMU */
+    6: double forceTorqueFilterCutoffInHz; /** Cutoff frequency(in Hz) of the first order filter of the F/T sensors */
+    7: double jointVelFilterCutoffInHz;    /** Cutoff frequency(in Hz) of the first order filter of the joint velocities */
+    8: double jointAccFilterCutoffInHz;    /** Cutoff frequency(in Hz) of the first order filter of the joint accelerations */
+    9: bool useJointVelocity; /** Use the joint velocity measurement if this is true, assume they are zero otherwise. */
+    10: bool useJointAcceleration; /** Use the joint acceleration measurment if this is true, assume they are zero otherwise. */
 }

--- a/src/modules/wholeBodyDynamics3/app/conf/wholeBodyDynamicsDevice.ini
+++ b/src/modules/wholeBodyDynamics3/app/conf/wholeBodyDynamicsDevice.ini
@@ -1,6 +1,7 @@
 device wholebodydynamics
 axesNames (torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)
 modelFile model.urdf
+imuFrameName imu_frame
 fixedFrameGravity (0,0,-9.81)
 alwaysUpdateAllVirtualTorqueSensors true
 


### PR DESCRIPTION
* Add imuFrameName to wholeBodyDynamicsSettings
* Add imuFrameName to wholebodydynamics device options
* Use settings.imuFrameName in the code
* Updated configuration files

@gabrielenava can you update accordingly the configuration files in the `.local` of `iCubGenova02`?
@fjandrad This is the device performing the estimation of external wrenches, if you want you can check out this changes to understand how it is working.