### PR TITLE
Cleanup of CMakeLists of devices

### DIFF
--- a/src/devices/floatingBaseEstimator/CMakeLists.txt
+++ b/src/devices/floatingBaseEstimator/CMakeLists.txt
@@ -10,30 +10,36 @@ include(YarpInstallationHelpers)
 
 yarp_configure_external_installation(codyco)
 
-yarp_prepare_device(floatingbaseestimator TYPE yarp::dev::floatingBaseEstimator INCLUDE "floatingBaseEstimator.h")
+yarp_prepare_plugin(floatingbaseestimator CATEGORY device
+                                          TYPE yarp::dev::floatingBaseEstimator
+                                          INCLUDE "floatingBaseEstimator.h"
+                                          DEFAULT ON
+                                          ADVANCED ON)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+if(ENABLE_codycomod_floatingbaseestimator)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-include_directories(SYSTEM
-                    ${YARP_INCLUDE_DIRS}
-                    ${EIGEN3_INCLUDE_DIR})
+    include_directories(SYSTEM
+                        ${YARP_INCLUDE_DIRS}
+                        ${EIGEN3_INCLUDE_DIR})
 
-yarp_add_plugin(floatingBaseEstimator floatingBaseEstimator.h floatingBaseEstimator.cpp)
+    yarp_add_plugin(floatingBaseEstimator floatingBaseEstimator.h floatingBaseEstimator.cpp)
 
-target_link_libraries(floatingBaseEstimator floatingBaseEstimatorRPC
-                                            ctrlLibRT
-                                            ${YARP_LIBRARIES}
-                                            ${iDynTree_LIBRARIES})
+    target_link_libraries(floatingBaseEstimator floatingBaseEstimatorRPC
+                                                ctrlLibRT
+                                                ${YARP_LIBRARIES}
+                                                ${iDynTree_LIBRARIES})
 
-if(MSVC)
-   add_definitions(-D_USE_MATH_DEFINES)
+    if(MSVC)
+        add_definitions(-D_USE_MATH_DEFINES)
+    endif()
+
+
+    yarp_install(TARGETS floatingBaseEstimator
+                 EXPORT CoDyCo
+                 COMPONENT runtime
+                 LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
+
+    yarp_install(FILES floatingbaseestimator.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
 endif()
-
-
-yarp_install(TARGETS floatingBaseEstimator
-             EXPORT CoDyCo
-             COMPONENT runtime
-             LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
-             ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
-
-yarp_install(FILES floatingbaseestimator.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})

--- a/src/devices/genericSensorClient/CMakeLists.txt
+++ b/src/devices/genericSensorClient/CMakeLists.txt
@@ -9,22 +9,27 @@ include(YarpInstallationHelpers)
 
 yarp_configure_external_installation(codyco)
 
-yarp_prepare_plugin(genericSensorClient CATEGORY device TYPE yarp::dev::GenericSensorClient INCLUDE "GenericSensorClient.h")
+yarp_prepare_plugin(genericSensorClient CATEGORY device
+                                        TYPE yarp::dev::GenericSensorClient
+                                        INCLUDE "GenericSensorClient.h"
+                                        DEFAULT ON
+                                        ADVANCED ON)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+if(ENABLE_codycomod_genericSensorClient)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-include_directories(SYSTEM
-                    ${YARP_INCLUDE_DIRS})
+    include_directories(SYSTEM
+                        ${YARP_INCLUDE_DIRS})
 
-yarp_add_plugin(genericSensorClient GenericSensorClient.h GenericSensorClient.cpp)
+    yarp_add_plugin(genericSensorClient GenericSensorClient.h GenericSensorClient.cpp)
 
-target_link_libraries(genericSensorClient ${YARP_LIBRARIES})
+    target_link_libraries(genericSensorClient ${YARP_LIBRARIES})
 
+    yarp_install(TARGETS genericSensorClient
+                 EXPORT CoDyCo
+                 COMPONENT runtime
+                 LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
 
-yarp_install(TARGETS genericSensorClient
-             EXPORT CoDyCo
-             COMPONENT runtime
-             LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
-             ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
-
-yarp_install(FILES genericSensorClient.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
+    yarp_install(FILES genericSensorClient.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
+endif()

--- a/src/devices/jointTorqueControl/CMakeLists.txt
+++ b/src/devices/jointTorqueControl/CMakeLists.txt
@@ -12,12 +12,22 @@ include(YarpInstallationHelpers)
 
 yarp_configure_external_installation(codyco)
 
-yarp_prepare_device(passThroughControlBoard TYPE yarp::dev::PassThroughControlBoard INCLUDE PassThroughControlBoard.h WRAPPER controlboardwrapper)
-yarp_prepare_device(jointTorqueControl TYPE yarp::dev::JointTorqueControl INCLUDE JointTorqueControl.h WRAPPER controlboardwrapper)
+yarp_prepare_plugin(passThroughControlBoard CATEGORY device
+                                            TYPE yarp::dev::PassThroughControlBoard
+                                            INCLUDE PassThroughControlBoard.h
+                                            DEFAULT ON
+                                            ADVANCED ON
+                                            WRAPPER controlboardwrapper)
+yarp_prepare_plugin(jointTorqueControl CATEGORY device
+                                       TYPE yarp::dev::JointTorqueControl
+                                       INCLUDE JointTorqueControl.h
+                                       DEFAULT ON
+                                       ADVANCED ON
+                                       WRAPPER controlboardwrapper)
 
 set(ENABLE_codycomod_jointTorqueControl TRUE)
 
-if(NOT SKIP_jointTorqueControl)
+if(ENABLE_codycomod_jointTorqueControl)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
     include_directories(SYSTEM
@@ -52,6 +62,5 @@ if(NOT SKIP_jointTorqueControl)
     add_subdirectory(app)
     
     yarp_install(FILES jointTorqueControl.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
-    
 endif()
 

--- a/src/devices/virtualAnalogClient/CMakeLists.txt
+++ b/src/devices/virtualAnalogClient/CMakeLists.txt
@@ -9,22 +9,26 @@ include(YarpInstallationHelpers)
 
 yarp_configure_external_installation(codyco)
 
-yarp_prepare_device(virtualAnalogClient TYPE yarp::dev::VirtualAnalogClient INCLUDE "VirtualAnalogClient.h")
+yarp_prepare_plugin(virtualAnalogClient CATEGORY device
+                                        TYPE yarp::dev::VirtualAnalogClient
+                                        INCLUDE "VirtualAnalogClient.h"
+                                        DEFAULT ON
+                                        ADVANCED ON)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+if(ENABLE_codycomod_virtualAnalogClient)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+    include_directories(SYSTEM
+                        ${YARP_INCLUDE_DIRS})
 
-include_directories(SYSTEM
-                    ${YARP_INCLUDE_DIRS})
+    yarp_add_plugin(virtualAnalogClient VirtualAnalogClient.h VirtualAnalogClient.cpp)
 
-yarp_add_plugin(virtualAnalogClient VirtualAnalogClient.h VirtualAnalogClient.cpp)
+    target_link_libraries(virtualAnalogClient ${YARP_LIBRARIES})
 
-target_link_libraries(virtualAnalogClient ${YARP_LIBRARIES})
+    yarp_install(TARGETS virtualAnalogClient
+                 EXPORT CoDyCo
+                 COMPONENT runtime
+                 LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
 
-
-yarp_install(TARGETS virtualAnalogClient
-             EXPORT CoDyCo
-             COMPONENT runtime
-             LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
-             ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
-
-yarp_install(FILES virtualAnalogClient.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
+    yarp_install(FILES virtualAnalogClient.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
+endif()

--- a/src/devices/virtualAnalogRemapper/CMakeLists.txt
+++ b/src/devices/virtualAnalogRemapper/CMakeLists.txt
@@ -9,23 +9,28 @@ include(YarpInstallationHelpers)
 
 yarp_configure_external_installation(codyco)
 
-yarp_prepare_device(virtualAnalogRemapper TYPE yarp::dev::VirtualAnalogRemapper INCLUDE "VirtualAnalogRemapper.h")
+yarp_prepare_plugin(virtualAnalogRemapper CATEGORY device
+                                          TYPE yarp::dev::VirtualAnalogRemapper
+                                          INCLUDE "VirtualAnalogRemapper.h"
+                                          DEFAULT ON
+                                          ADVANCED ON)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+if(ENABLE_codycomod_virtualAnalogRemapper)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-include_directories(SYSTEM
-                    ${YARP_INCLUDE_DIRS})
+    include_directories(SYSTEM
+                        ${YARP_INCLUDE_DIRS})
 
-yarp_add_plugin(virtualAnalogRemapper VirtualAnalogRemapper.h VirtualAnalogRemapper.cpp)
+    yarp_add_plugin(virtualAnalogRemapper VirtualAnalogRemapper.h VirtualAnalogRemapper.cpp)
 
-target_link_libraries(virtualAnalogRemapper ${YARP_LIBRARIES})
+    target_link_libraries(virtualAnalogRemapper ${YARP_LIBRARIES})
 
+    yarp_install(TARGETS virtualAnalogRemapper
+                 EXPORT CoDyCo
+                 COMPONENT runtime
+                 LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
 
-yarp_install(TARGETS virtualAnalogRemapper
-             EXPORT CoDyCo
-             COMPONENT runtime
-             LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
-             ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
-
-yarp_install(FILES virtualAnalogRemapper.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
+    yarp_install(FILES virtualAnalogRemapper.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
+endif()
 

--- a/src/devices/wholeBodyDynamics/CMakeLists.txt
+++ b/src/devices/wholeBodyDynamics/CMakeLists.txt
@@ -12,35 +12,41 @@ include(YarpInstallationHelpers)
 
 yarp_configure_external_installation(codyco)
 
-yarp_prepare_plugin(wholebodydynamics CATEGORY device TYPE yarp::dev::WholeBodyDynamicsDevice INCLUDE "WholeBodyDynamicsDevice.h")
+yarp_prepare_plugin(wholebodydynamics CATEGORY device
+                                      TYPE yarp::dev::WholeBodyDynamicsDevice
+                                      INCLUDE "WholeBodyDynamicsDevice.h"
+                                      DEFAULT ON
+                                      ADVANCED ON)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+if(ENABLE_codycomod_wholebodydynamics)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-include_directories(SYSTEM
-                    ${YARP_INCLUDE_DIRS}
-                    ${EIGEN3_INCLUDE_DIR}
-                    ${skinDynLib_INCLUDE_DIRS})
+    include_directories(SYSTEM
+                        ${YARP_INCLUDE_DIRS}
+                        ${EIGEN3_INCLUDE_DIR}
+                        ${skinDynLib_INCLUDE_DIRS})
 
-yarp_add_plugin(wholeBodyDynamicsDevice WholeBodyDynamicsDevice.h WholeBodyDynamicsDevice.cpp
-                                        SixAxisForceTorqueMeasureHelpers.h SixAxisForceTorqueMeasureHelpers.cpp
-                                        GravityCompensationHelpers.h GravityCompensationHelpers.cpp)
+    yarp_add_plugin(wholeBodyDynamicsDevice WholeBodyDynamicsDevice.h WholeBodyDynamicsDevice.cpp
+                                            SixAxisForceTorqueMeasureHelpers.h SixAxisForceTorqueMeasureHelpers.cpp
+                                            GravityCompensationHelpers.h GravityCompensationHelpers.cpp)
 
-target_link_libraries(wholeBodyDynamicsDevice wholeBodyDynamicsSettings
-                                              wholeBodyDynamics_IDLServer
-                                              ctrlLibRT
-                                              ${YARP_LIBRARIES}
-                                              skinDynLib
-                                              ${iDynTree_LIBRARIES})
+    target_link_libraries(wholeBodyDynamicsDevice   wholeBodyDynamicsSettings
+                                                    wholeBodyDynamics_IDLServer
+                                                    ctrlLibRT
+                                                    ${YARP_LIBRARIES}
+                                                    skinDynLib
+                                                    ${iDynTree_LIBRARIES})
 
-if(MSVC)
-   add_definitions(-D_USE_MATH_DEFINES)
+    if(MSVC)
+        add_definitions(-D_USE_MATH_DEFINES)
+    endif()
+
+
+    yarp_install(TARGETS wholeBodyDynamicsDevice
+                 EXPORT CoDyCo
+                 COMPONENT runtime
+                 LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
+
+    yarp_install(FILES wholebodydynamics.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})
 endif()
-
-
-yarp_install(TARGETS wholeBodyDynamicsDevice
-             EXPORT CoDyCo
-             COMPONENT runtime
-             LIBRARY DESTINATION ${CODYCO_DYNAMIC_PLUGINS_INSTALL_DIR}
-             ARCHIVE DESTINATION ${CODYCO_STATIC_PLUGINS_INSTALL_DIR})
-
-yarp_install(FILES wholebodydynamics.ini DESTINATION ${CODYCO_PLUGIN_MANIFESTS_INSTALL_DIR})


### PR DESCRIPTION
Solve https://github.com/robotology/codyco-modules/issues/205.
For now the options still default to OFF using YARP 2.3.66, but
default to ON if using YARP >= 2.3.67 .