### PR TITLE
Bump iDynTree required version to 0.8.1

### DIFF
--- a/cmake/modules/CoDyCoFindDependencies.cmake
+++ b/cmake/modules/CoDyCoFindDependencies.cmake
@@ -1,7 +1,7 @@
 #### Find Eigen3
 find_package(Eigen3 3.2 REQUIRED)
 
-find_package(iDynTree 0.3.14 REQUIRED)
+find_package(iDynTree 0.8.1 REQUIRED)
 find_package(yarpWholeBodyInterface 0.3.5 REQUIRED)
 find_package(paramHelp 0.0.3 REQUIRED)
 find_package(TinyXML)


### PR DESCRIPTION
See https://github.com/robotology/idyntree/pull/378 .