### PR TITLE
Added home positions for one foot balancing

### DIFF
--- a/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancing.ini
@@ -3,6 +3,20 @@ robot icub
 //parts to be opened by the GUI            
 parts (head torso left_arm right_arm right_leg left_leg)                
   
+[customPosition_NewController]
+/$robot/head_Position             0             0             0             0	          0  	        0      
+/$robot/head_Velocity             10            10            10            10            10            10
+/$robot/torso_Position            0             0             0      
+/$robot/torso_Velocity            10            10            10             
+/$robot/left_arm_Position        -29.8          29.8          0             45            0             0             25          15	     30	    10	     0	     0 	     0	    10	     0	   10        
+/$robot/left_arm_Velocity         10            10            10            10            30            30            30          10         10     10      10      10      10      10      10     10        
+/$robot/right_arm_Position       -29.8          29.8          0             45            0             0             25          15	     30	    10	     0	     0 	     0	    10	     0	   10
+/$robot/right_arm_Velocity        10            10            10            10            30            30            30          10         10     10      10      10      10      10      10     10       
+/$robot/right_leg_Position        0             0             0             0             0             0        
+/$robot/right_leg_Velocity        10            10            10            10            10            10         
+/$robot/left_leg_Position         0             0             0             0             0             0
+/$robot/left_leg_Velocity         10            10            10            10            10            10 
+
 [customPosition_YogaPP]
 /$robot/head_Position            0             0             0   	    0	          0  	        0      
 /$robot/head_Velocity            10            10            10             10            10            10
@@ -39,8 +53,38 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/left_arm_Position       -93.127        25            22.396        32            0             0             0        15	  30	  10	0	0	0	10	0	10
 /$robot/left_arm_Velocity        10            10            10            10            10            10            10       10          10      10    10      10      10      10      10      10  
 /$robot/right_arm_Position      -93.127        25            22.396        32            0             0             0        15	  30	  10	0	0	0	10	0	10    
-/$robot/right_arm_Velocity       10            10            10            10            10            10            10       10          10      10    10      10      10      10      10      10  
+/$robot/right_arm_Velocity       10            10            10            10            10            10            10       10          10      10    10      10      10      10      10      10
 /$robot/right_leg_Position       84            12.6          0            -98.976       -14.5          0 
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
 /$robot/left_leg_Position        84            12.6          0            -98.976       -14.5          0 
-/$robot/left_leg_Velocity        10            10            10            10            10            10        
+/$robot/left_leg_Velocity        10            10            10            10            10            10    
+
+[customPosition_OnLeftFoot]
+/$robot/head_Position            0             0             0                 0             0             0 
+/$robot/head_Velocity            10            10            10                10            10            10  
+/$robot/torso_Position           0             17           -1              
+/$robot/torso_Velocity           10            10            10                      
+/$robot/left_arm_Position       -37            94            0             50            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79    
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_arm_Position      -37            51            0             35            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79     
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_leg_Position       12            17            0            -10           -6             4  
+/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00         
+/$robot/left_leg_Position        22            28            0            -17           -5.5           1.5      
+/$robot/left_leg_Velocity        10            10            10            10            10            10             
+
+[customPosition_OnRightFoot]
+/$robot/head_Position            0             0             0                 0             0             0 
+/$robot/head_Velocity            10            10            10                10            10            10  
+/$robot/torso_Position           0            -17            1              
+/$robot/torso_Velocity           10            10            10                      
+/$robot/left_arm_Position       -37            51            0             35            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79    
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_arm_Position      -37            94            0             50            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79     
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_leg_Position       22            28            0            -17           -6             1.5  
+/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00         
+/$robot/left_leg_Position        12            17            0            -10           -5.5           4      
+/$robot/left_leg_Velocity        10            10            10            10            10            10  
+
+    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancingLeftFoot.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancingLeftFoot.ini
@@ -1,0 +1,99 @@
+//name of the robot          
+name icub      
+//parts to be opened by the GUI            
+parts (head torso left_arm right_arm right_leg left_leg)               
+ 
+[head_zero]    
+//                          0             1             2            
+PositionZero                0             0             0                 0             0             0            
+VelocityZero                10            10            10                10            10            10            
+
+[torso_zero]   
+//                          0             1             2              
+PositionZero                0             17           -1              
+VelocityZero                10            10            10             
+ 
+[left_arm_zero]              
+//Joint                     0             1             2             3             4             5             6             
+PositionZero               -37            94            0             50            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79    
+VelocityZero                10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+ 
+[right_arm_zero]             
+//Joint                     0             1             2             3             4             5             6             
+PositionZero               -37            51            0             35            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79  
+VelocityZero                10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+ 
+[right_leg_zero]             
+//Joint                     0             1             2             3             4             5               
+PositionZero                12            17            0            -10           -6             4      
+VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
+ 
+[left_leg_zero]              
+//Joint                     0             1             2             3             4             5               
+PositionZero                22            28            0            -17           -5.5           1.5         
+VelocityZero                10            10            10            10            10            10             
+ 
+//DO NOT REMOVE THIS LINE    
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 

--- a/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancing.ini
@@ -44,3 +44,31 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
 /$robot/left_leg_Position        84.00         12            0            -100.00       -12.00         0.00         
 /$robot/left_leg_Velocity        10            10            10            10            10            10        
+
+[customPosition_OnLeftFoot]
+/$robot/head_Position            0             0             0                 0             0             0 
+/$robot/head_Velocity            10            10            10                10            10            10  
+/$robot/torso_Position           0             17           -1              
+/$robot/torso_Velocity           10            10            10                      
+/$robot/left_arm_Position       -37            94            0             50            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79    
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_arm_Position      -37            51            0             35            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79     
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_leg_Position       12            17            0            -10           -6             4  
+/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00         
+/$robot/left_leg_Position        22            28            0            -17           -5.5           1.5      
+/$robot/left_leg_Velocity        10            10            10            10            10            10             
+
+[customPosition_OnRightFoot]
+/$robot/head_Position            0             0             0                 0             0             0 
+/$robot/head_Velocity            10            10            10                10            10            10  
+/$robot/torso_Position           0            -17            1              
+/$robot/torso_Velocity           10            10            10                      
+/$robot/left_arm_Position       -37            51            0             35            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79    
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_arm_Position      -37            94            0             50            0             0             0            14.82  30.01  1.71  0.24  7.85  1.81  6.67  0.17  -8.79     
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30           10     10     10    10    10    10    10    10     10
+/$robot/right_leg_Position       22            28            0            -17           -6             1.5  
+/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00         
+/$robot/left_leg_Position        12            17            0            -10           -5.5           4      
+/$robot/left_leg_Velocity        10            10            10            10            10            10  


### PR DESCRIPTION
Added a couple of new home positions for iCubGenova04 and icubGazeboSim. In particular:

- Balancing (position control) on one foot, both left and right;
- The home position used in the new torque balancing controller;
- A standalone file containing the home position for balancing on left foot for back-compatibility. But maybe we can remove it (I will open an issue for removing all old config files for balancing).
