### PR TITLE
Added a custom home position for checking the joints offsets calibration

### DIFF
--- a/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancing.ini
@@ -44,6 +44,20 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
 /$robot/left_leg_Position        12            5             0            -10           -3            -5 
 /$robot/left_leg_Velocity        10            10            10            10            10            10             
+
+[customPosition_CheckJointCalibration]
+/$robot/head_Position            0             0             0              0             0          0
+/$robot/head_Velocity            10            10            10             10            10         10
+/$robot/torso_Position           0             0             0
+/$robot/torso_Velocity           10            10            10
+/$robot/left_arm_Position       -90.0          15.0          15.0          90.0         -0.00          23.00        -0.00        15     30      10      0       0       0       10      0       10
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
+/$robot/right_arm_Position      -90.0          15.0          15.0          90.0         -0.00          23.00        -0.00        15     30      10      0       0       0       10      0       10
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
+/$robot/right_leg_Position       0             10            0             0             0            -10
+/$robot/right_leg_Velocity       10            10            10            10            10            10
+/$robot/left_leg_Position        0             10            0             0             0            -10
+/$robot/left_leg_Velocity        10            10            10            10            10            10
   
 [customPosition_OnChair]
 /$robot/head_Position            0             0             0   	    0	          0  	        0      


### PR DESCRIPTION
Added a custom home position for checking the joints offsets. The chosen reference joint positions are:
- legs: all set to 0 except hip roll and ankle roll respectively set to 10, -10
- torso: all set to 0
- arms: set as per the [ArmFineCalibration](http://wiki.icub.org/wiki/ArmFineCalibration) wiki.

For using these settings, select `[customPosition_CheckJointCalibration]` among the custom positions.