### PR TITLE
Allow specifying wholeBodyDynamics port prefix as config file parameter

### DIFF
--- a/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -632,6 +632,14 @@ bool WholeBodyDynamicsDevice::loadSettingsFromConfig(os::Searchable& config)
         return false;
     }
 
+    // Set the port prefix. The default value "/wholeBodyDynamics"
+    // is set in the device constructor
+    if( prop.check("portPrefix") &&
+        prop.find("portPrefix").isString())
+    {
+        portPrefix = prop.find("portPrefix").asString();
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Right now the port prefix is hardcoded, and executing more than one device on the same yarp namespace fails.

This PR adds the possibility to specify in the xml file the following parameter:

```xml
<param name="portPrefix">/iCub/wholeBodyDynamics</param>
```

that overrides the default value `wholeBodyDynamics`. If the parameter is not specified in the xml file, the old behavior is not affected.

This is necessary for having Gazebo multi-robot support (https://github.com/robotology/WB-Toolbox/issues/37, https://github.com/robotology/gazebo-yarp-plugins/issues/93).