### PR TITLE
Add useJointVelocity and useJointAcceleration options

### DIFF
--- a/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
+++ b/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp
@@ -562,8 +562,6 @@ bool WholeBodyDynamicsDevice::loadSettingsFromConfig(os::Searchable& config)
 {
     // Fill setting with their default values
     settings.kinematicSource             = IMU;
-    settings.useJointVelocity            = true;
-    settings.useJointAcceleration        = true;
     settings.imuFilterCutoffInHz         = 3.0;
     settings.forceTorqueFilterCutoffInHz = 3.0;
     settings.jointVelFilterCutoffInHz    = 3.0;
@@ -638,6 +636,30 @@ bool WholeBodyDynamicsDevice::loadSettingsFromConfig(os::Searchable& config)
         prop.find("portPrefix").isString())
     {
         portPrefix = prop.find("portPrefix").asString();
+    }
+
+    std::string useJointVelocityOptionName = "useJointVelocity";
+    if( !(prop.check(useJointVelocityOptionName.c_str()) && prop.find(useJointVelocityOptionName.c_str()).isBool()) )
+    {
+        yWarning() << "wholeBodyDynamics: useJointVelocity bool parameter missing, please specify it.";
+        yWarning() << "wholeBodyDynamics: setting useJointVelocity to the default value of true, but this is a deprecated behaviour that will be removed in the future.";
+        settings.useJointVelocity = true;
+    }
+    else
+    {
+        settings.useJointVelocity = prop.find(useJointVelocityOptionName.c_str()).asBool();
+    }
+
+    std::string useJointAccelerationOptionName = "useJointAcceleration";
+    if( !(prop.check(useJointAccelerationOptionName.c_str()) && prop.find(useJointAccelerationOptionName.c_str()).isBool()) )
+    {
+        yWarning() << "wholeBodyDynamics: useJointAcceleration bool parameter missing, please specify it.";
+        yWarning() << "wholeBodyDynamics: setting useJointAcceleration to the default value of true, but this is a deprecated behaviour that will be removed in the future.";
+        settings.useJointAcceleration = true;
+    }
+    else
+    {
+        settings.useJointAcceleration = prop.find(useJointAccelerationOptionName.c_str()).asBool();
     }
 
     return true;

--- a/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
+++ b/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h
@@ -119,7 +119,7 @@ class wholeBodyDynamicsDeviceFilters
  * |:--------------:|:--------------:|:-----------------:|:-----:|:-------------:|:--------:|:-----------------------------------------------------------------:|:-----:|
  * | axesNames      |      -         | vector of strings |   -   |   -           | Yes      | Ordered list of the axes that are part of the remapped device.    |       |
  * | modelFile      |      -         | path to file      |   -   | model.urdf    | No       | Path to the URDF file used for the kinematic and dynamic model.   |       |
- * | assumeFixed    |                | frame name        |   -   |     -         | No       | If it is present, the initial kinematic source used for estimation will be that specified frame is fixed, and its gravity is specified by fixedFrameGravity. Otherwise, the default IMU will be used. | |
+ * | assume_fixed    |                | frame name        |   -   |     -         | No       | If it is present, the initial kinematic source used for estimation will be that specified frame is fixed, and its gravity is specified by fixedFrameGravity. Otherwise, the default IMU will be used. | |
  * | fixedFrameGravity  |      -     | vector of doubles | m/s^2 | -             | Yes      | Gravity of the frame that is assumed to be fixed, if the kinematic source used is the fixed frame. | |
  * | imuFrameName   |       -        | string            |   -   |      -        | Yes      | Name of the frame (in the robot model) with respect to which the IMU broadcast its sensor measurements. |  |
  * | imuFilterCutoffInHz |     -     | double            | Hz    |      -        | Yes      | Cutoff frequency of the filter used to filter IMU measures. | The used filter is a simple first order filter. |
@@ -129,6 +129,8 @@ class wholeBodyDynamicsDeviceFilters
  * | defaultContactFrames      | -   | vector of strings (name of frames ) |-| - |  Yes     | Vector of default contact frames. If no external force read from the skin is found on a given submodel, the defaultContactFrames list is scanned and the first frame found on the submodel is the one at which origin the unknown contact force is assumed to be. | - |
  * | alwaysUpdateAllVirtualTorqueSensors | -     |  bool |  -    |      -        |  Yes     | Enforce that a virtual sensor for each estimated axes is available. | Tipically this is set to false when the device is running in the robot, while to true if it is running outside the robot. |
  * | defaultContactFrames |      -   | vector of strings |  -    |    -          | Yes      | If not data is read from the skin, specify the location of the default contacts | For each submodel induced by the FT sensor, the first not used frame that belongs to that submodel is selected from the list. An error is raised if not suitable frame is found for a submodel. |
+ * | useJointVelocity     |        - | bool              |  -    |      true     |  No      | Select if the measured joint velocities (read from the getEncoderSpeeds method) are used for estimation, or if they should be forced to 0.0 . | The default value of true is deprecated, and in the future the parameter will be required. |
+ * | useJointAcceleration |        - | bool              |  -    |      true     |  No      | Select if the measured joint accelerations (read from the getEncoderAccelerations method) are used for estimation, or if they should be forced to 0.0 . | The default value of true is deprecated, and in the future the parameter will be required. |
  * | IDYNTREE_SKINDYNLIB_LINKS |  -  | group             | -     | -             | Yes      |  Group describing the mapping between link names and skinDynLib identifiers. | |
  * |                |   linkName_1   | string (name of a link in the model) | - | - | Yes   | Bottle of three elements describing how the link with linkName is described in skinDynLib: the first element is the name of the frame in which the contact info is expressed in skinDynLib (tipically DH frames), the second a integer describing the skinDynLib BodyPart , and the third a integer describing the skinDynLib LinkIndex  | |
  * |                |   ...   | string (name of a link in the model) | - | -     | Yes      | Bottle of three elements describing how the link with linkName is described in skinDynLib: the first element is the name of the frame in which the contact info is expressed in skinDynLib (tipically DH frames), the second a integer describing the skinDynLib BodyPart , and the third a integer describing the skinDynLib LinkIndex  | |
@@ -208,6 +210,8 @@ class wholeBodyDynamicsDeviceFilters
  *         <param name="fixedFrameGravity">(0,0,-9.81)</param>
  *         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
  *         <param name="imuFrameName">imu_frame</param>
+ *         <param name="useJointVelocity">true</param>
+ *         <param name="useJointAcceleration">true</param>
  *         <!-- map between iDynTree links (identified by a name)
  *              and skinDynLib links (identified by their frame name, a BodyPart enum
  *              and a local (to the body part) index -->

--- a/src/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-and-can-six-fts.xml
+++ b/src/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-and-can-six-fts.xml
@@ -8,6 +8,8 @@
         <param name="fixedFrameGravity">(0,0,-9.81)</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_lower_leg,r_lower_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/src/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-six-fts-sim.xml
+++ b/src/devices/wholeBodyDynamics/app/wholebodydynamics-icub-external-six-fts-sim.xml
@@ -8,6 +8,8 @@
         <param name="fixedFrameGravity">(0,0,-9.81)</param>
         <param name="defaultContactFrames">(l_hand,r_hand,root_link,l_sole,r_sole,l_upper_leg,r_upper_leg,l_elbow_1,r_elbow_1)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/src/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-external.xml
+++ b/src/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-external.xml
@@ -8,6 +8,8 @@
         <param name="fixedFrameGravity">(0,0,-9.81)</param>
         <param name="defaultContactFrames">(root_link,l_sole,r_sole,l_lower_leg,r_lower_leg)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/src/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-robot.xml
+++ b/src/devices/wholeBodyDynamics/app/wholebodydynamics-icubheidelberg01-robot.xml
@@ -8,6 +8,8 @@
         <param name="fixedFrameGravity">(0,0,-9.81)</param>
         <param name="defaultContactFrames">(root_link,l_sole,r_sole,l_lower_leg,r_lower_leg)</param>
         <param name="imuFrameName">imu_frame</param>
+        <param name="useJointVelocity">true</param>
+        <param name="useJointAcceleration">true</param>
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum


### PR DESCRIPTION
Useful as a workaround if there are bugs or problems in the measurements reported by YARP controlboard in the `getEncoderSpeeds` or `getEncoderAccelerations`, such as it was happening in https://github.com/robotology/codyco-modules/issues/261 . 

@gabrielenava can you check if it is working as intended? Thanks! 