### PR TITLE
Make robots home positions symmetric

### DIFF
--- a/src/modules/torqueBalancing/app/robots/iCubDarmstadt01/homePoseBalancingTorsoHeadZero.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubDarmstadt01/homePoseBalancingTorsoHeadZero.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -3            -5       
+PositionZero                12            5             0            -10           -4            -5       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubDarmstadt01/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubDarmstadt01/homePoseBalancingTwoFeet.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -3            -5       
+PositionZero                12            5             0            -10           -4            -5       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGazeboV2_5/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGazeboV2_5/homePoseBalancing.ini
@@ -26,9 +26,9 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/left_arm_Velocity        10            10            10            10            10            10            10         
 /$robot/right_arm_Position      -35.97         29.97         0.06          50.00         0.00          0.00          0.00            
 /$robot/right_arm_Velocity       10            10            10            10            10            10            10         
-/$robot/right_leg_Position       12            5             0            -10           -1.6          -4         
+/$robot/right_leg_Position       12            5             0            -10           -1.6          -5         
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
-/$robot/left_leg_Position        12            5             0            -10           -2.8          -5
+/$robot/left_leg_Position        12            5             0            -10           -1.6          -5
 /$robot/left_leg_Velocity        10            10            10            10            10            10             
   
 [customPosition_OnChair]

--- a/src/modules/torqueBalancing/app/robots/iCubGazeboV2_5_plus/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGazeboV2_5_plus/homePoseBalancing.ini
@@ -40,9 +40,9 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/left_arm_Velocity        10            10            10            10            10            10            10         
 /$robot/right_arm_Position      -35.97         29.97         0.06          50.00         0.00          0.00          0.00            
 /$robot/right_arm_Velocity       10            10            10            10            10            10            10         
-/$robot/right_leg_Position       12            5             0            -10           -1.6          -4         
+/$robot/right_leg_Position       12            5             0            -10           -1.6          -5         
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
-/$robot/left_leg_Position        12            5             0            -10           -2.8          -5
+/$robot/left_leg_Position        12            5             0            -10           -1.6          -5
 /$robot/left_leg_Velocity        10            10            10            10            10            10             
   
 [customPosition_OnChair]

--- a/src/modules/torqueBalancing/app/robots/iCubGenova02/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova02/homePoseBalancing.ini
@@ -28,7 +28,7 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/right_arm_Velocity       10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
 /$robot/right_leg_Position       12            5             0            -10           -4            -5
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
-/$robot/left_leg_Position        12            5             0            -10           -3            -5 
+/$robot/left_leg_Position        12            5             0            -10           -4            -5 
 /$robot/left_leg_Velocity        10            10            10            10            10            10             
   
 [customPosition_OnChair]

--- a/src/modules/torqueBalancing/app/robots/iCubGenova02/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova02/homePoseBalancingTwoFeet.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -3            -5       
+PositionZero                12            5             0            -10           -4            -5       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova03/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova03/homePoseBalancingTwoFeet.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -1.6          -4        
+PositionZero                12            5             0            -10           -1.6          -5        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -2.8          -5          
+PositionZero                12            5             0            -10           -1.6          -5          
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancing.ini
@@ -42,7 +42,7 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/right_arm_Velocity       10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
 /$robot/right_leg_Position       12            5             0            -10           -4            -5
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
-/$robot/left_leg_Position        12            5             0            -10           -3            -5 
+/$robot/left_leg_Position        12            5             0            -10           -4            -5 
 /$robot/left_leg_Velocity        10            10            10            10            10            10             
 
 [customPosition_CheckJointCalibration]

--- a/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseBalancingTwoFeet.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -3            -5       
+PositionZero                12            5             0            -10           -4            -5       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseFineCalibration.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova04/homePoseFineCalibration.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                0             0             0            0              0             0        
+PositionZero                0             0             0             0             0             0        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                 0            0             0              0            0             0       
+PositionZero                0             0             0             0             0             0       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseBalancingLegsZero.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseBalancingLegsZero.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                0             0             0             0              0            0
+PositionZero                0             0             0             0             0             0
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseBalancingTorsoHeadZero.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseBalancingTorsoHeadZero.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -3            -5       
+PositionZero                12            5             0            -10           -4            -5       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseBalancingTwoFeet.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -3            -5       
+PositionZero                12            5             0            -10           -4            -5       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseFineCalibration.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGenova05/homePoseFineCalibration.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                0             0             0            0              0             0        
+PositionZero                0             0             0             0              0             0        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                 0            0             0              0            0             0       
+PositionZero                0             0             0             0             0             0       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubHeidelberg01/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubHeidelberg01/homePoseBalancingTwoFeet.ini
@@ -17,7 +17,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -20           -7            -3        
+PositionZero                12            5             0            -20           -7            -5        
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE   

--- a/src/modules/torqueBalancing/app/robots/iCubNancy01/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubNancy01/homePoseBalancing.ini
@@ -4,7 +4,7 @@ robot icub
 parts (head torso left_arm right_arm right_leg left_leg)                
   
 [customPosition_YogaPP]
-/$robot/head_Position           -1.5             0             0   	    0	          0  	        0      
+/$robot/head_Position           -1.5           0             0   	    0	          0  	        0      
 /$robot/head_Velocity            10            10            10             10            10            10
 /$robot/torso_Position           0             0            -10      
 /$robot/torso_Velocity           10            10            10             
@@ -28,7 +28,7 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/right_arm_Velocity       10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
 /$robot/right_leg_Position       12            5             0            -10           -4            -5
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
-/$robot/left_leg_Position        12            5             0            -10           -3            -5 
+/$robot/left_leg_Position        12            5             0            -10           -4            -5 
 /$robot/left_leg_Velocity        10            10            10            10            10            10             
   
 [customPosition_OnChair]

--- a/src/modules/torqueBalancing/app/robots/iCubParis01/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubParis01/homePoseBalancingTwoFeet.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -1.6          -4        
+PositionZero                12            5             0            -10           -1.6          -5        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -2.8          -5          
+PositionZero                12            5             0            -10           -1.6          -5          
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubParis02/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubParis02/homePoseBalancingTwoFeet.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -1.6          -4        
+PositionZero                12            5             0            -10           -1.6          -5        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -2.8          -5          
+PositionZero                12            5             0            -10           -1.6          -5          
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/iCubParis02/homePoseFineCalibration.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubParis02/homePoseFineCalibration.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                0             0             0            0              0             0        
+PositionZero                0             0             0             0             0             0        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                 0            0             0              0            0             0       
+PositionZero                0             0             0             0             0             0       
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancing.ini
@@ -26,9 +26,9 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/left_arm_Velocity        10            10            10            10            10            10            10         
 /$robot/right_arm_Position      -35.97         29.97         0.06          50.00         0.00          0.00          0.00            
 /$robot/right_arm_Velocity       10            10            10            10            10            10            10         
-/$robot/right_leg_Position       12            5             0            -10           -1.6          -4         
+/$robot/right_leg_Position       12            5             0            -10           -1.6          -5         
 /$robot/right_leg_Velocity       10            10            10            10            10            10         
-/$robot/left_leg_Position        12            5             0            -10           -2.8          -5
+/$robot/left_leg_Position        12            5             0            -10           -1.6          -5
 /$robot/left_leg_Velocity        10            10            10            10            10            10            
   
 [customPosition_OnChair]

--- a/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingLegsZero.ini
+++ b/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingLegsZero.ini
@@ -25,12 +25,12 @@ VelocityZero                10            10            10            10        
  
 [right_leg_zero]             
 //Joint                     0             1             2             3             4             5               
-PositionZero                0            -0.4           0             0            -0.4           0        
+PositionZero                0             0             0             0             0             0        
 VelocityZero                10.00         10.00         10.00         10.00         10.00         10.00          
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero               -0.7           0             0             0             1.8           0.6
+PositionZero                0             0             0             0             0             0
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    

--- a/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingRedBall.ini
+++ b/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingRedBall.ini
@@ -15,12 +15,12 @@ VelocityZero                10            10            10
  
 [left_arm_zero]              
 //Joint                     0             1             2             3             4             5             6             
-PositionZero               -35.97       29.97          0.06           50.00         -0.00        0.00          -0.00 
+PositionZero               -35.97         29.97         0.06         50.00         -0.00        0.00          -0.00 
 VelocityZero                10            10            10            10            30            30            30            
  
 [right_arm_zero]             
 //Joint                     0             1             2             3             4             5             6             
-PositionZero               -35.97         29.97         0.06         50.00          -0.00         0.00         -0.00  
+PositionZero               -35.97         29.97         0.06         50.00         -0.00        0.00         -0.00  
 VelocityZero                10            10            10            10            30            30            30            
  
 [right_leg_zero]             

--- a/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingTwoFeet.ini
+++ b/src/modules/torqueBalancing/app/robots/icubGazeboSim/homePoseBalancingTwoFeet.ini
@@ -30,7 +30,7 @@ VelocityZero                10.00         10.00         10.00         10.00     
  
 [left_leg_zero]              
 //Joint                     0             1             2             3             4             5               
-PositionZero                12            5             0            -10           -2.8          -5          
+PositionZero                12            5             0            -10           -1.6          -5          
 VelocityZero                10            10            10            10            10            10             
  
 //DO NOT REMOVE THIS LINE    


### PR DESCRIPTION
Follwing https://github.com/robotology/codyco-modules/issues/202, I decided to fix the very old problem of not having symmetric home positions. I mostly modified the home positions for two feet standing, only in the legs (in particular the ankle) joints.