### PR TITLE
Fix OnLeftFoot and OnRightFoot joints position for iCubGazeboV2_5

### DIFF
--- a/src/modules/torqueBalancing/app/robots/iCubGazeboV2_5/homePoseBalancing.ini
+++ b/src/modules/torqueBalancing/app/robots/iCubGazeboV2_5/homePoseBalancing.ini
@@ -46,29 +46,29 @@ parts (head torso left_arm right_arm right_leg left_leg)
 /$robot/left_leg_Velocity        10            10            10            10            10            10        
 
 [customPosition_OnLeftFoot]
-/$robot/head_Position            0             0             0                
-/$robot/head_Velocity            10            10            10           
-/$robot/torso_Position           0             17           -1              
-/$robot/torso_Velocity           10            10            10                      
-/$robot/left_arm_Position       -37            94            0             50            0             0             0             
-/$robot/left_arm_Velocity        10            10            10            10            30            30            30           
-/$robot/right_arm_Position      -37            51            0             35            0             0             0            
-/$robot/right_arm_Velocity       10            10            10            10            30            30            30           
-/$robot/right_leg_Position       12            17            0            -10           -6             4  
-/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00         
-/$robot/left_leg_Position        22            28            0            -17           -5.5           1.5      
-/$robot/left_leg_Velocity        10            10            10            10            10            10             
+/$robot/head_Position            0             0             0
+/$robot/head_Velocity            10            10            10
+/$robot/torso_Position           0            -6.0           2.7
+/$robot/torso_Velocity           5             5             5
+/$robot/left_arm_Position       -17.85         19.2          1.17          39.130        0             0             0
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30
+/$robot/right_arm_Position      -17.85         19.2          1.17          39.130        0             0             0
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30
+/$robot/right_leg_Position       1.2           11.55         0            -4            -1.8          -13.2
+/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00
+/$robot/left_leg_Position        1.2          -9.45          0             0             1.2           13.6
+/$robot/left_leg_Velocity        5             5             5             5             5             5
 
 [customPosition_OnRightFoot]
-/$robot/head_Position            0             0             0              
-/$robot/head_Velocity            10            10            10            
-/$robot/torso_Position           0            -17            1              
-/$robot/torso_Velocity           10            10            10                      
-/$robot/left_arm_Position       -37            51            0             35            0             0             0           
-/$robot/left_arm_Velocity        10            10            10            10            30            30            30           
-/$robot/right_arm_Position      -37            94            0             50            0             0             0            
-/$robot/right_arm_Velocity       10            10            10            10            30            30            30          
-/$robot/right_leg_Position       22            28            0            -17           -6             1.5  
-/$robot/right_leg_Velocity       10.00         10.00         10.00         10.00         10.00         10.00         
-/$robot/left_leg_Position        12            17            0            -10           -5.5           4      
-/$robot/left_leg_Velocity        10            10            10            10            10            10  
+/$robot/head_Position            0             0             0
+/$robot/head_Velocity            10            10            10
+/$robot/torso_Position           0             6.0           2.7
+/$robot/torso_Velocity           5             5             5
+/$robot/left_arm_Position       -17.85         19.2          1.17          39.130        0             0             0
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30
+/$robot/right_arm_Position      -17.85         19.2          1.17          39.130        0             0             0
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30
+/$robot/left_leg_Position        1.2           11.55         0            -4            -1.8          -13.2
+/$robot/left_leg_Velocity        10.00         10.00         10.00         10.00         10.00         10.00
+/$robot/right_leg_Position       1.2          -9.45          0             0             1.2           13.6
+/$robot/right_leg_Velocity       5             5             5             5             5             5


### PR DESCRIPTION
This fixes the joints position for the left and right one foot balancing (for iCubGazeboV2_5)

|       | Previous | Fixed |
|:-----:|:--------:|:-----:|
|  **Left** |   ![leftfail](https://user-images.githubusercontent.com/16744101/49509542-f0daa580-f885-11e8-942f-174a6ddeeedd.gif)       |  ![leftfix](https://user-images.githubusercontent.com/16744101/49509526-e6b8a700-f885-11e8-80e5-0788e54bba90.gif)     |
| **Right** |     ![rightfail](https://user-images.githubusercontent.com/16744101/49509555-fafca400-f885-11e8-93e5-66d590b224db.gif)    |    ![rightfix](https://user-images.githubusercontent.com/16744101/49509566-03ed7580-f886-11e8-9c64-096e5309f80c.gif)   |



